### PR TITLE
misc(syscall): remove calls field

### DIFF
--- a/modules/syscall-monitor/on_sys_enter.bpf.c
+++ b/modules/syscall-monitor/on_sys_enter.bpf.c
@@ -7,7 +7,6 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 #define MAX_SYSCALLS 512
 
 typedef struct activity {
-  uint64_t calls[MAX_SYSCALLS];
   uint64_t histogram[MAX_SYSCALLS];
 } activity_t;
 
@@ -66,7 +65,6 @@ int sys_enter(struct trace_event_raw_sys_enter *ctx) {
   // limit the index to avoid "unbounded memory access, make sure to bounds
   // check any array access into a map"
   uint32_t syscall_number = ctx->id & (MAX_SYSCALLS - 1);
-  activity->calls[syscall_number] = bpf_ktime_get_ns();
   activity->histogram[syscall_number]++;
   bpf_map_update_elem(&activities, &tgid, activity, BPF_ANY);
 

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -100,8 +100,6 @@ pub enum Payload {
     SyscallActivity {
         #[validatron(skip)]
         histogram: Vec<u64>,
-        #[validatron(skip)]
-        calls: Vec<u64>,
     },
     Bind {
         address: SocketAddr,


### PR DESCRIPTION
The calls field contained the timestamp of the last time a particular
syscall was invoked. It was never really used, so we've decided to
remove it.
