### PR TITLE
add list type to dsl

### DIFF
--- a/validatron/src/dsl.lalrpop
+++ b/validatron/src/dsl.lalrpop
@@ -1,6 +1,9 @@
 use std::str::FromStr;
 use crate::{Operator, Condition, Field, RelationalOperator, StringOperator, MultiOperator};
 
+use lalrpop_util::ParseError;
+use super::DslError;
+
 grammar;
 
 pub Condition: Condition = {
@@ -20,7 +23,45 @@ BaseCondition: Condition = {
         op,
         value
     },
+    <f: Field> "in" <list: ValueList> =>? {
+        let mut iterator = list.into_iter();
+
+        let first = Condition::Base {
+            field: f.clone(),
+            op: Operator::Relational(RelationalOperator::Equals),
+            value: iterator.next().ok_or(ParseError::User {
+                error: DslError::EmptyList
+            })?
+        };
+    
+        let ret_val = iterator.fold(first, |acc, x| {
+            Condition::Or {
+                l: Box::new(acc),
+                r: Box::new(Condition::Base {
+                    field: f.clone(),
+                    op: Operator::Relational(RelationalOperator::Equals),
+                    value: x
+                })
+            }
+        });
+    
+        Ok(ret_val)
+    },
     "(" <Condition> ")",
+}
+
+ValueList: Vec<String> = {
+    "[" <Comma<Value>> "]" => <>
+}
+
+Comma<T>: Vec<T> = {
+    <mut v:(<T> ",")*> <e:T?> => match e {
+        None => v,
+        Some(e) => {
+            v.push(e);
+            v
+        }
+    }
 }
 
 Value: String = {
@@ -44,5 +85,15 @@ Operator: Operator = {
 }
 
 Field: Field = {
-    <s: r"[a-zA-Z]\w+[\.[a-zA-Z]\w+]*"> => Field::from_str(<>).unwrap()
+    <s: r"[a-zA-Z]\w+[\.[a-zA-Z]\w+]*"> =>? Field::from_str(<>)
+        .map_err(|err| ParseError::User {
+            error: DslError::Field {
+                field: <>.to_string(),
+                cause: err.to_string()
+            }
+        })
+}
+
+extern {
+    type Error = DslError;
 }

--- a/validatron/src/parser.rs
+++ b/validatron/src/parser.rs
@@ -80,7 +80,7 @@ impl FromStr for Field {
 pub enum DslError {
     #[error("Empty list is not allowed")]
     EmptyList,
-    #[error("Error parsing field {field}: {}")]
+    #[error("Error parsing field {field}: {cause}")]
     Field { field: String, cause: String },
 }
 


### PR DESCRIPTION
# add list type to dsl

add list type handling in the rule engine dsl

## Implementation (Optional)

added list at the parser level

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
