### PR TITLE
Remove threshold from anomaly and malware events

### DIFF
--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -139,7 +139,6 @@ pub enum Payload {
     },
     MalwareDetection {
         score: f32,
-        threshold: f32,
         #[validatron(skip)]
         tags: Vec<String>,
     },
@@ -151,7 +150,6 @@ pub enum Payload {
     },
     AnomalyDetection {
         score: f32,
-        threshold: f32,
     }, // CustomJson { ty: i32, data: Vec<u8> },
        // CustomProto { ty: i32, data: Vec<u8> },
        // CustomRaw { ty: i32, data: Vec<u8> }


### PR DESCRIPTION
# Pull Request Title

Removing `threshold` field from `AnomalyDetection` and `MalwareDetection` events to implement `score` as the difference between the original score and the model threshold. 


## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
