### PR TITLE
fix(filtering): regression when initializing filter

### DIFF
--- a/modules/process-monitor/src/filtering/maps.rs
+++ b/modules/process-monitor/src/filtering/maps.rs
@@ -99,7 +99,7 @@ impl RuleMap {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub(crate) struct Image(pub(crate) [u8; MAX_IMAGE_LEN]);
 // We must explicitly mark Image as a plain old data which can be safely memcopied by aya.
 unsafe impl bpf_common::aya::Pod for Image {}
@@ -127,8 +127,14 @@ impl FromStr for Image {
 impl fmt::Display for Image {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for c in self.0.into_iter().take_while(|c| *c != 0) {
-            write!(f, "{}", c)?;
+            write!(f, "{}", c as char)?;
         }
         Ok(())
+    }
+}
+
+impl fmt::Debug for Image {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Image").field(&self.to_string()).finish()
     }
 }


### PR DESCRIPTION
`maps::Image::to_string()` formatted the bytes of the process
name as numbers instead of characters. This caused a failure
when initializing `map_interest` in modules/process-monitor/src/filtering/initializer.rs

```
let whitelist_match = self
    .config
    .whitelist
    .iter()
    .find(|r| r.image.to_string() == process.image);
let targets_match = self
    .config
    .targets
    .iter()
    .find(|r| r.image.to_string() == process.image);

```

# Pull Request Title

_Short introduction explaining the motivation and reasoning behind the pull request._

## Implementation (Optional)

_Feel free to include design and implementation for external review outside of the code changes._

## I have 

- [ ] run `cargo fmt`;
- [ ] run `cargo clippy`;
- [ ] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
