### PR TITLE
Test in modules/process-monitor - lookup echo path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "serial_test",
  "thiserror",
  "tokio",
+ "which",
 ]
 
 [[package]]
@@ -1960,6 +1961,17 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/modules/process-monitor/Cargo.toml
+++ b/modules/process-monitor/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1", features = ["full"] }
 nix = "0.24.0"
 log = "0.4"
 thiserror = "1"
+which = "4.2.5"
 
 [build-dependencies]
 bpf-common = { path = "../../bpf-common", features = ["build"] }

--- a/modules/process-monitor/Cargo.toml
+++ b/modules/process-monitor/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1", features = ["full"] }
 nix = "0.24.0"
 log = "0.4"
 thiserror = "1"
-which = "4.2.5"
 
 [build-dependencies]
 bpf-common = { path = "../../bpf-common", features = ["build"] }
@@ -20,3 +19,4 @@ bpf-common = { path = "../../bpf-common", features = ["build"] }
 [dev-dependencies]
 bpf-common = { path = "../../bpf-common", features = ["test-utils"] }
 serial_test = { version = "0.6.0" }
+which = "4.2.5"

--- a/modules/process-monitor/src/lib.rs
+++ b/modules/process-monitor/src/lib.rs
@@ -143,6 +143,7 @@ mod tests {
     use nix::unistd::execv;
     use nix::unistd::{fork, ForkResult};
     use std::ffi::CString;
+    use which::which;
 
     use super::*;
 
@@ -169,6 +170,8 @@ mod tests {
     #[serial_test::serial]
     async fn exec_event() {
         let mut child_pid = Pid::from_raw(0);
+        let echo_buff = which("echo").unwrap();
+        let echo_path: StringArray<NAME_MAX> = echo_buff.as_path().to_str().unwrap().into();
         test_runner()
             .run(|| {
                 let mut child = std::process::Command::new("echo").spawn().unwrap();
@@ -180,7 +183,7 @@ mod tests {
                 child_pid,
                 event_check!(
                     ProcessEvent::Exec,
-                    (filename, "/usr/bin/echo".into(), "exec filename")
+                    (filename, echo_path.into(), "exec filename")
                 ),
             );
     }


### PR DESCRIPTION
Instead of using a hardwired path "/usr/bin/echo" which
fails on some distributiones (ex. RHEL8), lookup the path
for 'echo' and use the resolved path for the check in test.

Below is the current test failure with the trunk (branch `main`) version.

Fixes #28.

Signed-off-by: Dmitry Savintsev <dsavints@gmail.com>

```
running 8 tests

test tests::exec_event ... FAILED
test tests::exit_cleans_up_resources ... ok








test tests::exec_updates_interest ... ok
test tests::exit_event ... ok
test tests::exit_event_no_thread ... ok
test tests::fork_event ... ok
test tests::inherit_policy ... ok
test tests::threads_are_ignored ... ok

failures:

---- tests::exec_event stdout ----
[INFO  bpf_common::trace_pipe] Logging events from /sys/kernel/debug/tracing/trace_pipe
1116747336537749 1320995 forked from 1320985
1116747336911537 1320995 exec /bin/echo
1116747337393856 1320995 exit(0)

1116747336911537 1320995 exec /bin/echo (3/4)
- pid: 1320995 (OK)
- timestamp: 1116747336469037 - 1116747337463098 (OK)
- event type: ProcessEvent :: Exec (OK)
- exec filename: (FAIL)
  |    found: StringArray { data: "/bin/echo" }
  | expected: StringArray { data: "/usr/bin/echo" }

thread 'tests::exec_event' panicked at 'No event found matching results', /home/dmitris/dev/hack/gh/Exein-io/pulsar/bpf-common/src/test_runner.rs:146:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::exec_event

test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.38s

error: test failed, to rerun pass '--lib'
```