### PR TITLE
Update `lalrpop-util` to include `lexer` feature

### DIFF
--- a/validatron/Cargo.toml
+++ b/validatron/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.53"
 log = "0.4"
 thiserror = "1.0.30"
 validatron-derive = {path = "derive"}
-lalrpop-util = "0.19.7"
+lalrpop-util = { version="0.19.7", features=["lexer"] }
 regex = "1"
 
 [build-dependencies]


### PR DESCRIPTION
# Update `lalrpop-util` to include `lexer` feature

Currently building in other projects can cause compilation errors due to missing imports similar to the ones described here - https://github.com/lalrpop/lalrpop/issues/650.

```
bhargav@bhargav-kk:/mnt/c/bhargav/Programming/Language-stuff/brim$ cargo run
   Compiling libc v0.2.116
   ...
   Compiling lalrpop v0.19.7
   Compiling brim v0.1.0 (/mnt/c/bhargav/Programming/Language-stuff/brim)
error[E0432]: unresolved import `self::__lalrpop_util::lexer`
  --> /mnt/c/bhargav/Programming/Language-stuff/brim/target/debug/build/brim-9358516eba536307/out/grammar.rs:22:31
   |
22 |     use self::__lalrpop_util::lexer::Token;
   |                               ^^^^^ could not find `lexer` in `__lalrpop_util`

...
For more information about an error, try `rustc --explain E0432`.
error: could not compile `brim` due to 5 previous errors
```

## Implementation (Optional)

Add feature flag as recommend [here](https://github.com/lalrpop/lalrpop/issues/650#issuecomment-1032308454).

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
