### PR TITLE
Replace Kprobes with LSM and tracepoints where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ We're requiring 5.5 because we use `BPF_CORE_READ`, which under the hood uses
 `bpf_probe_read_kernel`. To support older kernel versions we may use the older
 and generic `bpf_probe_read`.
 
+For the best results, make sure these kernel configurations are enabled:
+```
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_INFO_BTF=y
+CONFIG_SECURITY=y
+CONFIG_SECURITYFS=y
+CONFIG_BPF_LSM=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_FTRACE_SYSCALLS=y
+```
+
 See <https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md>
 
 ## Advanced

--- a/bpf-common/Cargo.toml
+++ b/bpf-common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [features]
 default = []
 build = ["tempfile"]
+test-suite = ["test-utils"]
 test-utils = []
 
 [dependencies]

--- a/bpf-common/src/feature_autodetect/lsm.rs
+++ b/bpf-common/src/feature_autodetect/lsm.rs
@@ -1,0 +1,29 @@
+use anyhow::{anyhow, Context, Result};
+
+/// Check if the system supports eBPF LSM programs.
+/// The kernel must be build with CONFIG_BPF_LSM=y, which is available
+/// since 5.7. This functionality should also be enabled, either at kernel
+/// compile time or in the `--lsm=` boot flags.
+/// `cat /sys/kernel/security/lsm` will list `bpf` on supported systems.
+pub async fn lsm_supported() -> bool {
+    match tokio::task::spawn_blocking(|| try_load())
+        .await
+        .context("Error in background task")
+    {
+        Ok(Ok(())) => true,
+        Err(err) | Ok(Err(err)) => {
+            log::warn!("LSM not supported: {:?}", err);
+            false
+        }
+    }
+}
+const PATH: &str = "/sys/kernel/security/lsm";
+
+fn try_load() -> Result<()> {
+    std::fs::read_to_string(PATH)
+        .with_context(|| format!("Reading {PATH} failed"))?
+        .split(',')
+        .any(|lsm_subsystem| lsm_subsystem == "bpf")
+        .then(|| ())
+        .ok_or_else(|| anyhow!("eBPF LSM programs disabled"))
+}

--- a/bpf-common/src/feature_autodetect/lsm.rs
+++ b/bpf-common/src/feature_autodetect/lsm.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Result};
 /// compile time or in the `--lsm=` boot flags.
 /// `cat /sys/kernel/security/lsm` will list `bpf` on supported systems.
 pub async fn lsm_supported() -> bool {
-    match tokio::task::spawn_blocking(|| try_load())
+    match tokio::task::spawn_blocking(try_load)
         .await
         .context("Error in background task")
     {

--- a/bpf-common/src/feature_autodetect/mod.rs
+++ b/bpf-common/src/feature_autodetect/mod.rs
@@ -1,0 +1,25 @@
+//! This module checks what features are supported by the runnig kernel
+pub mod lsm;
+
+#[cfg(feature = "test-suite")]
+pub mod test_suite {
+    use crate::test_runner::{TestCase, TestReport, TestSuite};
+
+    use super::lsm::lsm_supported;
+
+    pub fn tests() -> TestSuite {
+        TestSuite {
+            name: "feature_autodetect",
+            tests: vec![lsm()],
+        }
+    }
+
+    fn lsm() -> TestCase {
+        TestCase::new("lsm", async {
+            TestReport {
+                success: lsm_supported().await,
+                lines: vec![],
+            }
+        })
+    }
+}

--- a/bpf-common/src/lib.rs
+++ b/bpf-common/src/lib.rs
@@ -17,6 +17,7 @@ pub use program::{Program, ProgramBuilder, ProgramError};
 pub use aya;
 
 pub mod bpf_fs;
+pub mod feature_autodetect;
 
 /// Utility function to pretty print an error with its sources.
 ///

--- a/bpf-common/src/parsing/data_array.rs
+++ b/bpf-common/src/parsing/data_array.rs
@@ -40,8 +40,10 @@ impl<const T: usize> PartialEq for DataArray<T> {
 
 impl<const T: usize> fmt::Debug for DataArray<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = &self.data[..(self.copied_data_len as usize)];
         f.debug_struct("DataArray")
             .field("copied_data_len", &self.copied_data_len)
+            .field("data", &data)
             .finish()
     }
 }

--- a/bpf-common/src/program.rs
+++ b/bpf-common/src/program.rs
@@ -136,8 +136,8 @@ impl ProgramBuilder {
         self
     }
 
-    pub fn raw_tracepoint(mut self, raw_tracepoint: &str) -> Self {
-        self.raw_tracepoints.push(raw_tracepoint.to_string());
+    pub fn raw_tracepoint(mut self, name: &str) -> Self {
+        self.raw_tracepoints.push(name.to_string());
         self
     }
 

--- a/bpf-common/src/test_runner.rs
+++ b/bpf-common/src/test_runner.rs
@@ -1,9 +1,10 @@
 //! Test utility for eBPF programs
 //!
 //! Example usage taken from file-system-monitor:
-//! ```
+//! ```ignore
 //! #[cfg(feature = "test-suite")]
 //! pub mod test_suite {
+//!     use super::*;
 //!     use bpf_common::{
 //!         event_check,
 //!         test_runner::{TestCase, TestRunner, TestSuite},
@@ -16,15 +17,15 @@
 //!         }
 //!     }
 //!
-//!     fn file_name() -> TestCase {
+//!     fn open_file() -> TestCase {
 //!         TestCase::new("file_name", async {
-//!             const PATH: &str = "/tmp/file_name_1";
+//!             let path = std::env::temp_dir().join("file_name_1");
 //!             TestRunner::with_ebpf(program)
-//!                 .run(|| { std::fs::File::create(PATH); } )
+//!                 .run(|| { std::fs::File::create(&path); } )
 //!                 .await
 //!                 .expect_event(event_check!(
 //!                     FsEvent::FileCreated,
-//!                     (filename, PATH.into(), "filename")
+//!                     (filename, path.to_str().unwrap().into(), "filename")
 //!                 ))
 //!                 .report()
 //!         })

--- a/modules/file-system-monitor/probe.bpf.c
+++ b/modules/file-system-monitor/probe.bpf.c
@@ -200,7 +200,7 @@ static __always_inline void on_inode_create(void *ctx, struct inode *dir,
   struct event_t *event = bpf_map_lookup_elem(&eventmem, &key);
   if (!event)
     return;
-  // struct dentry *dentry = (struct dentry *)PT_REGS_PARM2(ctx);
+
   get_dentry_path_str(dentry, event->filename);
   event->event = FILE_CREATED;
   event->timestamp = bpf_ktime_get_ns();

--- a/modules/file-system-monitor/src/lib.rs
+++ b/modules/file-system-monitor/src/lib.rs
@@ -17,9 +17,9 @@ pub async fn program(
         MODULE_NAME,
         include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe.bpf.o")).into(),
     )
-    .kprobe("security_inode_create")
-    .kprobe("security_inode_unlink")
-    .kprobe("security_file_open")
+    .lsm("inode_create")
+    .lsm("inode_unlink")
+    .lsm("file_open")
     .start()
     .await?;
     program.read_events("events", sender).await?;

--- a/modules/file-system-monitor/src/lib.rs
+++ b/modules/file-system-monitor/src/lib.rs
@@ -17,6 +17,9 @@ pub async fn program(
         MODULE_NAME,
         include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe.bpf.o")).into(),
     );
+    // LSM hooks provide the perfet intercept point for file system operations.
+    // If LSM eBPF programs is not supported, we'll attach to the same kernel
+    // functions, but using kprobes.
     if lsm_supported().await {
         log::info!("Loading LSM programs");
         builder = builder

--- a/modules/network-monitor/probes.bpf.c
+++ b/modules/network-monitor/probes.bpf.c
@@ -534,7 +534,6 @@ int BPF_PROG(sys_exit_accept, struct pt_regs *regs, int __syscall_nr,
 SEC("tracepoint/sys_exit_recvmsg")
 int BPF_PROG(sys_exit_recvmsg, struct pt_regs *regs, int __syscall_nr,
              long ret) {
-  LOG_DEBUG("sys_exit_recvmsg %d", ret);
   do_recvmsg(ctx, ret);
   return 0;
 }
@@ -542,7 +541,6 @@ int BPF_PROG(sys_exit_recvmsg, struct pt_regs *regs, int __syscall_nr,
 SEC("tracepoint/sys_exit_recvmmsg")
 int BPF_PROG(sys_exit_recvmmsg, struct pt_regs *regs, int __syscall_nr,
              long ret) {
-  // LOG_DEBUG("sys_exit_recvmmsg %d", ret);
   do_recvmsg(ctx, ret);
   return 0;
 }
@@ -558,21 +556,18 @@ int BPF_PROG(sys_enter_recvfrom, struct pt_regs *regs, int __syscall_nr, int fd,
 SEC("tracepoint/sys_exit_recvfrom")
 int BPF_PROG(sys_exit_recvfrom, struct pt_regs *regs, int __syscall_nr,
              long ret) {
-  LOG_DEBUG("sys_exit_recvfrom %d", ret);
   do_recvmsg(ctx, ret);
   return 0;
 }
 
 SEC("tracepoint/sys_exit_read")
 int BPF_PROG(sys_exit_read, struct pt_regs *regs, int __syscall_nr, long ret) {
-  LOG_DEBUG("sys_exit_read %d", ret);
   do_recvmsg(ctx, ret);
   return 0;
 }
 
 SEC("tracepoint/sys_exit_readv")
 int BPF_PROG(sys_exit_readv, struct pt_regs *regs, int __syscall_nr, long ret) {
-  LOG_DEBUG("sys_exit_readv %d", ret);
   do_recvmsg(ctx, ret);
   return 0;
 }
@@ -615,6 +610,7 @@ int BPF_PROG(socket_recvmsg, struct socket *sock, struct msghdr *msg, int size,
 }
 
 /// Fallback kprobes if LSM programs not suported
+
 SEC("kprobe/security_socket_bind")
 int BPF_KPROBE(security_socket_bind, struct socket *sock,
                struct sockaddr *address, int addrlen) {
@@ -626,5 +622,26 @@ SEC("kprobe/security_socket_connect")
 int BPF_KPROBE(security_socket_connect, struct socket *sock,
                struct sockaddr *address, int addrlen) {
   on_socket_connect(ctx, sock, address, addrlen);
+  return 0;
+}
+
+SEC("kprobe/security_socket_accept")
+int BPF_KPROBE(security_socket_accept, struct socket *sock,
+               struct socket *newsock) {
+  on_socket_accept(ctx, sock, newsock);
+  return 0;
+}
+
+SEC("kprobe/security_socket_sendmsg")
+int BPF_KPROBE(security_socket_sendmsg, struct socket *sock, struct msghdr *msg,
+               int size) {
+  do_sendmsg(ctx, sock, msg, size);
+  return 0;
+}
+
+SEC("kprobe/security_socket_recvmsg")
+int BPF_KPROBE(security_socket_recvmsg, struct socket *sock, struct msghdr *msg,
+               int size, int flags) {
+  save_recvmsg(ctx, sock, msg);
   return 0;
 }

--- a/modules/network-monitor/probes.bpf.c
+++ b/modules/network-monitor/probes.bpf.c
@@ -105,7 +105,7 @@ struct bpf_map_def_aya SEC("maps/args_map") args_map = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(u64),                // bpf_get_current_pid_tgid()
     .value_size = sizeof(struct arguments), // data
-    .max_entries = 3,
+    .max_entries = 1024,
 };
 
 const int IPV6_NUM_OCTECTS = 16;

--- a/modules/network-monitor/src/lib.rs
+++ b/modules/network-monitor/src/lib.rs
@@ -22,27 +22,33 @@ pub async fn program(
     );
     if lsm_supported().await {
         builder = builder
+            // ok
             .lsm("socket_bind")
+
+            // connect
             .lsm("socket_connect")
+
+            // serve tracepoint all'uscita
             .lsm("socket_accept")
             .tracepoint("syscalls", "sys_exit_accept4")
             .tracepoint("syscalls", "sys_exit_accept")
-            //.kprobe("udp_sendmsg")
-            //.kprobe("udp_recvmsg")
-            //.kretprobe("udp_recvmsg")
-            //.kprobe("udpv6_sendmsg")
-            //.kprobe("udpv6_recvmsg")
-            //.kretprobe("udpv6_recvmsg")
-            //.kprobe("tcp_sendmsg")
-            //.kprobe("tcp_recvmsg")
-            //.kretprobe("tcp_recvmsg")
+
+            .lsm("socket_sendmsg")
+
+            .lsm("socket_recvmsg")
+            .tracepoint("syscalls", "sys_exit_recvmsg")
+            .tracepoint("syscalls", "sys_exit_recvmmsg")
+            .tracepoint("syscalls", "sys_enter_recvfrom")
+            .tracepoint("syscalls", "sys_exit_recvfrom")
+            .tracepoint("syscalls", "sys_exit_read")
+            .tracepoint("syscalls", "sys_exit_readv")
+
             //.kprobe("tcp_set_state")
             ;
     } else {
         builder = builder
             .kprobe("security_socket_bind")
             .kprobe("security_socket_connect")
-            //.kretprobe("inet_csk_accept")
             .kprobe("udp_sendmsg")
             .kprobe("udp_recvmsg")
             .kretprobe("udp_recvmsg")

--- a/modules/network-monitor/src/lib.rs
+++ b/modules/network-monitor/src/lib.rs
@@ -28,7 +28,7 @@ const MODULE_NAME: &str = "network-monitor";
 // that we can't find the source address when the hook is called.
 // During `socket_accept` we'll save the `struct socket` pointer, but we'll read it
 // only in the `sys_exit_accept`/`sys_exit_accept4` tracepoints, immediately before
-// the kernel exists the syscall which caused the "accept" in the first place.
+// the kernel exits the syscall which caused the "accept" in the first place.
 //
 // # Send
 // We read the address and content of sent messages using the `socket_sendmsg` LSM hook.

--- a/modules/network-monitor/src/lib.rs
+++ b/modules/network-monitor/src/lib.rs
@@ -24,8 +24,9 @@ pub async fn program(
         builder = builder
             .lsm("socket_bind")
             .lsm("socket_connect")
-            //.kprobe("security_socket_connect")
-            //.kretprobe("inet_csk_accept")
+            .lsm("socket_accept")
+            .tracepoint("syscalls", "sys_exit_accept4")
+            .tracepoint("syscalls", "sys_exit_accept")
             //.kprobe("udp_sendmsg")
             //.kprobe("udp_recvmsg")
             //.kretprobe("udp_recvmsg")
@@ -41,7 +42,7 @@ pub async fn program(
         builder = builder
             .kprobe("security_socket_bind")
             .kprobe("security_socket_connect")
-            .kretprobe("inet_csk_accept")
+            //.kretprobe("inet_csk_accept")
             .kprobe("udp_sendmsg")
             .kprobe("udp_recvmsg")
             .kretprobe("udp_recvmsg")

--- a/modules/process-monitor/src/lib.rs
+++ b/modules/process-monitor/src/lib.rs
@@ -347,7 +347,7 @@ pub mod test_suite {
                 interest_map.clear().unwrap();
 
                 // add rule to target echo
-                let image = "/usr/bin/echo";
+                let image = which("echo").unwrap().to_string_lossy().to_string();
                 let rule = Rule {
                     image: image.parse().unwrap(),
                     with_children,
@@ -366,7 +366,7 @@ pub mod test_suite {
                 for old_with_children in [true, false] {
                     // run the targeted command
                     let interest_map_ref = &mut interest_map;
-                    let child_pid = fork_and_run(move || {
+                    let child_pid = fork_and_run(|| {
                         // before calling exec, we want to update our interest
                         let old_value = PolicyDecision {
                             interesting: !is_target,
@@ -375,7 +375,7 @@ pub mod test_suite {
                         .as_raw();
                         let pid = std::process::id() as i32;
                         interest_map_ref.0.insert(pid, old_value, 0).unwrap();
-                        let exec_binary = CString::new(image).unwrap();
+                        let exec_binary = CString::new(image.as_str()).unwrap();
                         execv(
                             &exec_binary,
                             // -n flag suppresses echo newline character

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -104,7 +104,6 @@ pub enum Payload {
         address: SocketAddr,
     },
     Connect {
-        source: SocketAddr,
         destination: SocketAddr,
     },
     Accept {

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -11,7 +11,7 @@ network-monitor = { path = "../modules/network-monitor", features = ["test-suite
 process-monitor = { path = "../modules/process-monitor", features = ["test-suite"] }
 syscall-monitor = { path = "../modules/syscall-monitor", features = ["test-suite"] }
 libtest-mimic =  "0.4.1"
-bpf-common = { path = "../bpf-common", features = ["test-utils"] }
+bpf-common = { path = "../bpf-common", features = ["test-utils", "test-suite"] }
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
 futures = "0.3.21"

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -36,13 +36,13 @@ pub mod test_suite {
 
     fn file_name() -> TestCase {
         TestCase::new("file_name", async {
-            const PATH: &str = "/tmp/file_name_1";
+            let path = std::env::temp_dir().join("file_name_1");
             TestRunner::with_ebpf(program)
-                .run(|| { std::fs::File::create(PATH); } )
+                .run(|| { std::fs::File::create(&path); } )
                 .await
                 .expect_event(event_check!(
                     FsEvent::FileCreated,
-                    (filename, PATH.into(), "filename")
+                    (filename, path.to_str().unwrap().into(), "filename")
                 ))
                 .report()
         })

--- a/test-suite/src/main.rs
+++ b/test-suite/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
 
     // List of modules we want to test
     let modules = [
+        bpf_common::feature_autodetect::test_suite::tests(),
         file_system_monitor::test_suite::tests(),
         network_monitor::test_suite::tests(),
         process_monitor::test_suite::tests(),

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 tests
 pulsar-exec
+test-suite

--- a/vagrant/static.sh
+++ b/vagrant/static.sh
@@ -15,18 +15,12 @@ excluded="--exclude threat-response-lua"
 
 export CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
 cargo build --bin pulsar-exec ${features}
-
-# build all tests and get file list
-# https://github.com/rust-lang/cargo/issues/1924
-tests=$(cargo test --no-run --message-format=json ${features} --workspace ${excluded}| jq -r .executable? | grep deps)
+cargo build --bin test-suite ${features}
 
 for vagrantfile in vagrant/*/Vagrantfile
 do
   box=$(dirname $vagrantfile)
   cp "./target/${CARGO_BUILD_TARGET}/debug/pulsar-exec" "${box}/"
-  test_folder="${box}/tests/"
-  rm -rf "${test_folder}"
-  mkdir "${test_folder}"
-  cp ${tests} "${test_folder}"
+  cp "./target/${CARGO_BUILD_TARGET}/debug/test-suite" "${box}/"
 done
 

--- a/vagrant/ubuntu2204/Vagrantfile
+++ b/vagrant/ubuntu2204/Vagrantfile
@@ -1,0 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  config.vm.synced_folder ".", "/vagrant", disabled: false
+end


### PR DESCRIPTION
This PR replace Kprobes with LSM and tracepoints where possible.

- We [autodetect LSM support](https://github.com/Exein-io/pulsar/pull/56/files#diff-a8ae8336058aa3893a9f6d1c63ec04831c4f3f6b78dc0ad7ab676a5ec18b67b7) and [fallback to kprobes](https://github.com/Exein-io/pulsar/pull/56/files#diff-1547f532a7c21f359c4193b6f730b4929e84a35990dddffe49355802708116a7R29-R36) when it's not available.
- File-system-monitor was fully refactored to use LSM hooks
- Network-monitor was refactored to use a combination of LSM hooks and syscalls. [See in-depth explaination](https://github.com/Exein-io/pulsar/pull/56/files#diff-34c932019d747e6110c8c57a102f4b35c475ae2df73e1556407fc5c2bb647053R14-R47).
- Process-monitor kprobe usage was removed by using raw tracepoints.
- Except for fallbacks, the only kprobe usage left is for `tcp_set_state`, for the `close` event.


Fix https://github.com/Exein-io/pulsar/issues/55
