### PR TITLE
File system monitor improvements

### DIFF
--- a/bpf-common/include/common.bpf.h
+++ b/bpf-common/include/common.bpf.h
@@ -195,6 +195,8 @@ static __always_inline int is_thread(pid_t *out_tgid) {
   ___bpf_apply(UNTYPED_ARGS_, ___bpf_narg(args))(args)
 
 #define PULSAR_LSM_HOOK(hook_point, args...)                                   \
+  static __always_inline void on_##hook_point(void *ctx, TYPED_ARGS(args));    \
+                                                                               \
   SEC("lsm/" #hook_point)                                                      \
   int BPF_PROG(hook_point, TYPED_ARGS(args), int ret) {                        \
     on_##hook_point(ctx, UNTYPED_ARGS(args));                                  \

--- a/modules/file-system-monitor/probe.bpf.c
+++ b/modules/file-system-monitor/probe.bpf.c
@@ -228,7 +228,7 @@ void __always_inline on_file_link(void *ctx, struct dentry *old_dentry,
   event->pid = tgid;
   event->link.hard_link = true;
 
-  LOG_DEBUG("symlink %s -> %s", event->link.source, event->link.destination);
+  LOG_DEBUG("hardlink %s -> %s", event->link.source, event->link.destination);
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
                         sizeof(struct event_t));
   return;
@@ -316,14 +316,14 @@ int BPF_KPROBE(security_file_open, struct file *file) {
 }
 
 SEC("kprobe/security_path_link")
-int BPF_PROG(security_path_link, struct dentry *old_dentry,
+int BPF_KPROBE(security_path_link, struct dentry *old_dentry,
              struct path *new_dir, struct dentry *new_dentry) {
   on_file_link(ctx, old_dentry, new_dir, new_dentry);
   return 0;
 }
 
 SEC("kprobe/security_path_symlink")
-int BPF_PROG(security_path_symlink, struct path *dir, struct dentry *dentry,
+int BPF_KPROBE(security_path_symlink, struct path *dir, struct dentry *dentry,
              char *old_name) {
   on_file_symlink(ctx, dir, dentry, old_name);
   return 0;

--- a/modules/file-system-monitor/probe.bpf.c
+++ b/modules/file-system-monitor/probe.bpf.c
@@ -8,15 +8,31 @@ int my_pid = 0;
 #define FILE_CREATED 0
 #define FILE_DELETED 1
 #define FILE_OPENED 2
+#define FILE_LINK 3
 #define NAME_MAX 1024
 #define MAX_PATH_COMPONENTS 20
+
+struct file_opened_event {
+  char filename[NAME_MAX];
+  int flags;
+};
+
+struct file_link_event {
+  char source[NAME_MAX];
+  char destination[NAME_MAX];
+  bool hard_link;
+};
 
 struct event_t {
   u64 timestamp;
   pid_t pid;
-  u32 event;
-  char filename[NAME_MAX];
-  int flags;
+  u32 event_type;
+  union {
+    char created[NAME_MAX];
+    char deleted[NAME_MAX];
+    struct file_opened_event opened;
+    struct file_link_event link;
+  };
 };
 
 struct bpf_map_def SEC("maps/event") eventmem = {
@@ -35,34 +51,32 @@ struct bpf_map_def SEC("maps/events") events = {
 };
 
 // get_path_str was copied and adapted from Tracee
-static __always_inline void get_path_str(struct path *path,
+// vfsmnt is used to get the path of the mount point. If NULL, we can only get
+// the path up to the mount point.
+static __always_inline void get_path_str(struct dentry *dentry,
+                                         struct vfsmount *vfsmnt,
                                          char buf[NAME_MAX]) {
-  struct path f_path;
-  bpf_probe_read_kernel(&f_path, sizeof(struct path), path);
   char slash = '/';
   int zero = 0;
-  struct dentry *dentry = f_path.dentry;
-  struct vfsmount *vfsmnt = f_path.mnt;
-  struct mount *mnt_parent_p;
-
-  struct mount *mnt_p = container_of(vfsmnt, struct mount, mnt);
-  bpf_probe_read_kernel(&mnt_parent_p, sizeof(struct mount *),
-                        &mnt_p->mnt_parent);
+  struct mount *mnt_parent_p = NULL;
+  struct mount *mnt_p = NULL;
+  if (vfsmnt) {
+    mnt_p = container_of(vfsmnt, struct mount, mnt);
+    bpf_probe_read_kernel(&mnt_parent_p, sizeof(struct mount *),
+                          &mnt_p->mnt_parent);
+  }
 
   u32 buf_off = (NAME_MAX >> 1);
-  struct dentry *mnt_root;
-  struct dentry *d_parent;
-  struct qstr d_name;
-  unsigned int len;
-  unsigned int off;
-  int sz;
 
   if (buf == NULL)
     return;
 
 #pragma unroll
   for (int i = 0; i < MAX_PATH_COMPONENTS; i++) {
-    mnt_root = (struct dentry *)BPF_CORE_READ(vfsmnt, mnt_root);
+    struct dentry *mnt_root = NULL;
+    if (vfsmnt) {
+      mnt_root = (struct dentry *)BPF_CORE_READ(vfsmnt, mnt_root);
+    }
     struct dentry *d_parent = BPF_CORE_READ(dentry, d_parent);
     if (dentry == mnt_root || dentry == d_parent) {
       if (dentry != mnt_root) {
@@ -84,12 +98,12 @@ static __always_inline void get_path_str(struct path *path,
       break;
     }
     // Add this dentry name to path
-    d_name = BPF_CORE_READ(dentry, d_name);
-    len = (d_name.len + 1) & (NAME_MAX - 1);
-    off = buf_off - len;
+    struct qstr d_name = BPF_CORE_READ(dentry, d_name);
+    unsigned int len = (d_name.len + 1) & (NAME_MAX - 1);
+    unsigned int off = buf_off - len;
 
     // Is string buffer big enough for dentry name?
-    sz = 0;
+    int sz = 0;
     if (off <= buf_off) { // verify no wrap occurred
       len = len & ((NAME_MAX >> 1) - 1);
       sz = bpf_probe_read_kernel_str(&(buf[off & ((NAME_MAX >> 1) - 1)]), len,
@@ -111,69 +125,6 @@ static __always_inline void get_path_str(struct path *path,
   if (buf_off == (NAME_MAX >> 1)) {
     // memfd files have no path in the filesystem -> extract their name
     buf_off = 0;
-    d_name = BPF_CORE_READ(dentry, d_name);
-    bpf_probe_read_kernel_str(&(buf[0]), NAME_MAX, (void *)d_name.name);
-  } else {
-    // Add leading slash
-    buf_off -= 1;
-    bpf_probe_read_kernel(&(buf[buf_off & (NAME_MAX - 1)]), 1, &slash);
-    // Null terminate the path string
-    bpf_probe_read_kernel(&(buf[(NAME_MAX >> 1) - 1]), 1, &zero);
-
-    // Copy string to the start
-    int total_len = NAME_MAX - buf_off;
-    bpf_probe_read_kernel(buf, total_len & (NAME_MAX - 1),
-                          buf + (buf_off & NAME_MAX - 1));
-  }
-}
-
-// get_dentry_path_str was copied and adapted from Tracee
-static __always_inline void get_dentry_path_str(struct dentry *dentry,
-                                                char buf[NAME_MAX]) {
-  char slash = '/';
-  int zero = 0;
-
-  // TODO: remove >> 1?
-  u32 buf_off = (NAME_MAX >> 1);
-
-  if (buf == NULL)
-    return;
-
-#pragma unroll
-  for (int i = 0; i < MAX_PATH_COMPONENTS; i++) {
-    struct dentry *d_parent = BPF_CORE_READ(dentry, d_parent);
-
-    if (dentry == d_parent) {
-      break;
-    }
-    // Add this dentry name to path
-    struct qstr d_name = BPF_CORE_READ(dentry, d_name);
-    unsigned int len = (d_name.len + 1) & (NAME_MAX - 1);
-    unsigned int off = buf_off - len;
-    // Is string buffer big enough for dentry name?
-    int sz = 0;
-    if (off <= buf_off) { // verify no wrap occurred
-      len = len & ((NAME_MAX >> 1) - 1);
-      sz = bpf_probe_read_kernel_str(&(buf[off & ((NAME_MAX >> 1) - 1)]), len,
-                                     (void *)d_name.name);
-    } else {
-      break;
-    }
-    if (sz > 1) {
-      buf_off -= 1; // remove null byte termination with slash sign
-      bpf_probe_read_kernel(&(buf[buf_off & (NAME_MAX - 1)]), 1, &slash);
-      buf_off -= sz - 1;
-    } else {
-      // If sz is 0 or 1 we have an error (path can't be null nor an empty
-      // string)
-      break;
-    }
-    dentry = d_parent;
-  }
-
-  if (buf_off == (NAME_MAX >> 1)) {
-    // memfd files have no path in the filesystem -> extract their name
-    buf_off = 0;
     struct qstr d_name = BPF_CORE_READ(dentry, d_name);
     bpf_probe_read_kernel_str(&(buf[0]), NAME_MAX, (void *)d_name.name);
   } else {
@@ -182,6 +133,7 @@ static __always_inline void get_dentry_path_str(struct dentry *dentry,
     bpf_probe_read_kernel(&(buf[buf_off & (NAME_MAX - 1)]), 1, &slash);
     // Null terminate the path string
     bpf_probe_read_kernel(&(buf[(NAME_MAX >> 1) - 1]), 1, &zero);
+
     // Copy string to the start
     int total_len = NAME_MAX - buf_off;
     bpf_probe_read_kernel(buf, total_len & (NAME_MAX - 1),
@@ -201,12 +153,12 @@ static __always_inline void on_inode_create(void *ctx, struct inode *dir,
   if (!event)
     return;
 
-  get_dentry_path_str(dentry, event->filename);
-  event->event = FILE_CREATED;
+  get_path_str(dentry, NULL, event->created);
+  event->event_type = FILE_CREATED;
   event->timestamp = bpf_ktime_get_ns();
   event->pid = tgid;
 
-  LOG_DEBUG("create %s", event->filename);
+  LOG_DEBUG("create %s", event->created);
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
                         sizeof(struct event_t));
 }
@@ -221,12 +173,12 @@ static __always_inline void on_inode_unlink(void *ctx, struct inode *dir,
   struct event_t *event = bpf_map_lookup_elem(&eventmem, &key);
   if (!event)
     return;
-  get_dentry_path_str(dentry, event->filename);
-  event->event = FILE_DELETED;
+  get_path_str(dentry, NULL, event->deleted);
+  event->event_type = FILE_DELETED;
   event->timestamp = bpf_ktime_get_ns();
   event->pid = tgid;
 
-  LOG_DEBUG("unlink %s", event->filename);
+  LOG_DEBUG("unlink %s", event->deleted);
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
                         sizeof(struct event_t));
   return;
@@ -242,13 +194,64 @@ void __always_inline on_file_open(void *ctx, struct file *file) {
   if (!event)
     return;
   struct path path = BPF_CORE_READ(file, f_path);
-  get_path_str(&path, event->filename);
-  event->event = FILE_OPENED;
+  get_path_str(path.dentry, path.mnt, event->opened.filename);
+  event->event_type = FILE_OPENED;
   event->timestamp = bpf_ktime_get_ns();
   event->pid = tgid;
-  event->flags = BPF_CORE_READ(file, f_flags);
+  event->opened.flags = BPF_CORE_READ(file, f_flags);
 
-  LOG_DEBUG("open %s", event->filename);
+  LOG_DEBUG("open %s", event->opened.filename);
+  bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
+                        sizeof(struct event_t));
+  return;
+}
+
+void __always_inline on_file_link(void *ctx, struct dentry *old_dentry,
+                                  struct path *new_dir,
+                                  struct dentry *new_dentry) {
+  pid_t tgid = interesting_tgid();
+  if (tgid < 0)
+    return;
+
+  u32 key = 0;
+  struct event_t *event = bpf_map_lookup_elem(&eventmem, &key);
+  if (!event)
+    return;
+
+  struct vfsmount *vfsmnt = BPF_CORE_READ(new_dir, mnt);
+  get_path_str(new_dentry, vfsmnt, event->link.source);
+  get_path_str(old_dentry, vfsmnt, event->link.destination);
+  event->event_type = FILE_LINK;
+  event->timestamp = bpf_ktime_get_ns();
+  event->pid = tgid;
+  event->link.hard_link = true;
+
+  LOG_DEBUG("symlink %s -> %s", event->link.source, event->link.destination);
+  bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
+                        sizeof(struct event_t));
+  return;
+}
+
+void __always_inline on_file_symlink(void *ctx, struct path *dir,
+                                     struct dentry *dentry, char *old_name) {
+  pid_t tgid = interesting_tgid();
+  if (tgid < 0)
+    return;
+
+  u32 key = 0;
+  struct event_t *event = bpf_map_lookup_elem(&eventmem, &key);
+  if (!event)
+    return;
+
+  struct vfsmount *vfsmnt = BPF_CORE_READ(dir, mnt);
+  get_path_str(dentry, vfsmnt, event->link.source);
+  bpf_probe_read_kernel_str(event->link.destination, NAME_MAX, old_name);
+  event->event_type = FILE_LINK;
+  event->timestamp = bpf_ktime_get_ns();
+  event->pid = tgid;
+  event->link.hard_link = false;
+
+  LOG_DEBUG("symlink %s -> %s", event->link.source, event->link.destination);
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
                         sizeof(struct event_t));
   return;
@@ -275,6 +278,20 @@ int BPF_PROG(file_open, struct file *file, int ret) {
   return ret;
 }
 
+SEC("lsm/path_link")
+int BPF_PROG(path_link, struct dentry *old_dentry, struct path *new_dir,
+             struct dentry *new_dentry, int ret) {
+  on_file_link(ctx, old_dentry, new_dir, new_dentry);
+  return ret;
+}
+
+SEC("lsm/path_symlink")
+int BPF_PROG(path_symlink, struct path *dir, struct dentry *dentry,
+             char *old_name, int ret) {
+  on_file_symlink(ctx, dir, dentry, old_name);
+  return ret;
+}
+
 /// Fallback kprobes
 
 SEC("kprobe/security_inode_create")
@@ -294,5 +311,19 @@ int BPF_KPROBE(security_inode_unlink, struct inode *dir,
 SEC("kprobe/security_file_open")
 int BPF_KPROBE(security_file_open, struct file *file) {
   on_file_open(ctx, file);
+  return 0;
+}
+
+SEC("kprobe/security_path_link")
+int BPF_PROG(security_path_link, struct dentry *old_dentry,
+             struct path *new_dir, struct dentry *new_dentry) {
+  on_file_link(ctx, old_dentry, new_dir, new_dentry);
+  return 0;
+}
+
+SEC("kprobe/security_path_symlink")
+int BPF_PROG(security_path_symlink, struct path *dir, struct dentry *dentry,
+             char *old_name) {
+  on_file_symlink(ctx, dir, dentry, old_name);
   return 0;
 }

--- a/modules/file-system-monitor/src/lib.rs
+++ b/modules/file-system-monitor/src/lib.rs
@@ -51,6 +51,12 @@ pub enum FsEvent {
     FileDeleted {
         filename: StringArray<NAME_MAX>,
     },
+    DirCreated {
+        filename: StringArray<NAME_MAX>,
+    },
+    DirDeleted {
+        filename: StringArray<NAME_MAX>,
+    },
     FileOpened {
         filename: StringArray<NAME_MAX>,
         flags: Flags,
@@ -61,6 +67,11 @@ pub enum FsEvent {
         destination: StringArray<NAME_MAX>,
         hard_link: bool,
     },
+    #[allow(clippy::large_enum_variant)]
+    FileRename {
+        source: StringArray<NAME_MAX>,
+        destination: StringArray<NAME_MAX>,
+    },
 }
 
 impl fmt::Display for FsEvent {
@@ -68,6 +79,8 @@ impl fmt::Display for FsEvent {
         match self {
             FsEvent::FileCreated { filename } => write!(f, "created {}", filename),
             FsEvent::FileDeleted { filename } => write!(f, "deleted {}", filename),
+            FsEvent::DirCreated { filename } => write!(f, "created dir {}", filename),
+            FsEvent::DirDeleted { filename } => write!(f, "deleted dir {}", filename),
             FsEvent::FileOpened { filename, flags } => {
                 write!(f, "open {} ({})", filename, flags.0)
             }
@@ -82,6 +95,10 @@ impl fmt::Display for FsEvent {
                 source,
                 destination
             ),
+            FsEvent::FileRename {
+                source,
+                destination,
+            } => write!(f, "rename {} -> {}", source, destination),
         }
     }
 }
@@ -189,6 +206,12 @@ pub mod pulsar {
                 FsEvent::FileDeleted { filename } => Payload::FileDeleted {
                     filename: filename.to_string(),
                 },
+                FsEvent::DirCreated { filename } => Payload::DirCreated {
+                    dirname: filename.to_string(),
+                },
+                FsEvent::DirDeleted { filename } => Payload::DirDeleted {
+                    dirname: filename.to_string(),
+                },
                 FsEvent::FileOpened { filename, flags } => Payload::FileOpened {
                     filename: filename.to_string(),
                     flags: flags.0,
@@ -201,6 +224,13 @@ pub mod pulsar {
                     source: source.to_string(),
                     destination: destination.to_string(),
                     hard_link,
+                },
+                FsEvent::FileRename {
+                    source,
+                    destination,
+                } => Payload::FileRename {
+                    source: source.to_string(),
+                    destination: destination.to_string(),
                 },
             }
         }

--- a/modules/file-system-monitor/src/lib.rs
+++ b/modules/file-system-monitor/src/lib.rs
@@ -371,10 +371,10 @@ pub mod test_suite {
         TestCase::new("symlink", async {
             let source = temp_dir().join("source");
             let destination = temp_dir().join("destination");
+            _ = std::fs::remove_file(&source);
+            _ = std::fs::remove_file(&destination);
             TestRunner::with_ebpf(program)
                 .run(|| {
-                    _ = std::fs::remove_file(&source);
-                    _ = std::fs::remove_file(&destination);
                     std::os::unix::fs::symlink(&destination, &source).unwrap();
                 })
                 .await
@@ -396,12 +396,12 @@ pub mod test_suite {
         TestCase::new("hardlink", async {
             let source = temp_dir().join("source");
             let destination = temp_dir().join("destination");
+            _ = std::fs::remove_file(&source);
+            _ = std::fs::remove_file(&destination);
+            // destination must exist for an hardlink to be created
+            std::fs::write(&destination, b"hello world").unwrap();
             TestRunner::with_ebpf(program)
                 .run(|| {
-                    _ = std::fs::remove_file(&source);
-                    _ = std::fs::remove_file(&destination);
-                    // destination must exist for an hardlink to be created
-                    std::fs::write(&destination, b"hello world").unwrap();
                     std::fs::hard_link(&destination, &source).unwrap();
                 })
                 .await

--- a/modules/file-system-monitor/src/lib.rs
+++ b/modules/file-system-monitor/src/lib.rs
@@ -23,7 +23,7 @@ pub async fn program(
     if lsm_supported().await {
         log::info!("Loading LSM programs");
         builder = builder
-            .lsm("inode_create")
+            .lsm("path_mknod")
             .lsm("path_unlink")
             .lsm("file_open")
             .lsm("path_link")
@@ -31,7 +31,7 @@ pub async fn program(
     } else {
         log::info!("LSM programs not supported. Falling back to kprobes");
         builder = builder
-            .kprobe("security_inode_create")
+            .kprobe("security_path_mknod")
             .kprobe("security_path_unlink")
             .kprobe("security_file_open")
             .kprobe("security_path_link")

--- a/modules/network-monitor/probes.bpf.c
+++ b/modules/network-monitor/probes.bpf.c
@@ -219,6 +219,8 @@ static __always_inline void copy_skc_dest(struct sock_common *sk,
   }
 }
 
+PULSAR_LSM_HOOK(socket_bind, struct socket *, sock, struct sockaddr *, address,
+                int, addrlen);
 void __always_inline on_socket_bind(void *ctx, struct socket *sock,
                                     struct sockaddr *address, int addrlen) {
   pid_t tgid = interesting_tgid();
@@ -238,6 +240,8 @@ void __always_inline on_socket_bind(void *ctx, struct socket *sock,
   return;
 }
 
+PULSAR_LSM_HOOK(socket_connect, struct socket *, sock, struct sockaddr *,
+                address, int, addrlen);
 static __always_inline void on_socket_connect(void *ctx, struct socket *sock,
                                               struct sockaddr *address,
                                               int addrlen) {
@@ -258,6 +262,7 @@ static __always_inline void on_socket_connect(void *ctx, struct socket *sock,
                         sizeof(struct network_event));
 }
 
+PULSAR_LSM_HOOK(socket_accept, struct socket *, sock, struct socket *, newsock);
 static __always_inline void on_socket_accept(void *ctx, struct socket *sock,
                                              struct socket *newsock) {
   // This LSM hook is invoked on accept calls, which happens before
@@ -337,6 +342,8 @@ static __always_inline u16 get_sock_protocol(struct sock *sk) {
   }
 }
 
+PULSAR_LSM_HOOK(socket_sendmsg, struct socket *, sock, struct msghdr *, msg,
+                int, size);
 static __always_inline void on_socket_sendmsg(void *ctx, struct socket *sock,
                                               struct msghdr *msg, int size) {
   pid_t tgid = interesting_tgid();
@@ -381,6 +388,8 @@ static __always_inline void save_recvmsg_addr(void *ctx,
   bpf_map_update_elem(&args_map, &pid_tgid, &args, BPF_ANY);
 }
 
+PULSAR_LSM_HOOK(socket_recvmsg, struct socket *, sock, struct msghdr *, msg,
+                int, size, int, flags);
 static __always_inline void on_socket_recvmsg(void *ctx, struct socket *sock,
                                               struct msghdr *msg, int size,
                                               int flags) {
@@ -583,13 +592,3 @@ int BPF_PROG(sys_exit_readv, struct pt_regs *regs, int __syscall_nr, long ret) {
   return 0;
 }
 
-/// LSM hook points
-PULSAR_LSM_HOOK(socket_bind, struct socket *, sock, struct sockaddr *, address,
-                int, addrlen);
-PULSAR_LSM_HOOK(socket_connect, struct socket *, sock, struct sockaddr *,
-                address, int, addrlen);
-PULSAR_LSM_HOOK(socket_accept, struct socket *, sock, struct socket *, newsock);
-PULSAR_LSM_HOOK(socket_sendmsg, struct socket *, sock, struct msghdr *, msg,
-                int, size);
-PULSAR_LSM_HOOK(socket_recvmsg, struct socket *, sock, struct msghdr *, msg,
-                int, size, int, flags);

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -83,6 +83,11 @@ pub enum Payload {
         filename: String,
         flags: i32,
     },
+    FileLink {
+        source: String,
+        destination: String,
+        hard_link: bool,
+    },
     ElfOpened {
         filename: String,
         flags: i32,

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -79,6 +79,12 @@ pub enum Payload {
     FileDeleted {
         filename: String,
     },
+    DirCreated {
+        dirname: String,
+    },
+    DirDeleted {
+        dirname: String,
+    },
     FileOpened {
         filename: String,
         flags: i32,
@@ -87,6 +93,10 @@ pub enum Payload {
         source: String,
         destination: String,
         hard_link: bool,
+    },
+    FileRename {
+        source: String,
+        destination: String,
     },
     ElfOpened {
         filename: String,
@@ -154,9 +164,10 @@ pub enum Payload {
     },
     AnomalyDetection {
         score: f32,
-    }, // CustomJson { ty: i32, data: Vec<u8> },
-       // CustomProto { ty: i32, data: Vec<u8> },
-       // CustomRaw { ty: i32, data: Vec<u8> }
+    },
+    // CustomJson { ty: i32, data: Vec<u8> },
+    // CustomProto { ty: i32, data: Vec<u8> },
+    // CustomRaw { ty: i32, data: Vec<u8> }
 }
 
 /// Encapsulates data of a DNS question.

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -32,6 +32,15 @@ $ vagrant halt
 
 # Common issues
 
+## Missing IPv6
+
+Many network monitor tests require an IPv6 address, which is unconfigured on
+most vagrant boxes. It's adviced to run this before executing the test-suite:
+
+```bash
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+```
+
 ## ssh issues
 
 If `vagrant up` doesn't complete, make sure ssh-rsa keys are enabled:


### PR DESCRIPTION
## New events: file rename, directory creation, directory deletion, symbolic link, hard link

Hook into LSM `path_rename`, `path_rmdir`, `path_mkdir`, `path_link` and `path_symlink`. As usual, we use kprobes as a fallback.

Fix #64 and #67 



## Fix bug #11

I fixed bug #11 by using the LSM hooks accepting a path argument. This requires the `CONFIG_SECURITY_PATH` config variable.
Unify the two path extraction functions to require a `struct path*`.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
