### PR TITLE
Add listen event and exec arguments

### DIFF
--- a/modules/process-monitor/src/filtering/initializer.rs
+++ b/modules/process-monitor/src/filtering/initializer.rs
@@ -60,6 +60,7 @@ pub(crate) async fn setup_events_filter(
             pid: process.pid,
             image: process.image.to_string(),
             timestamp: Timestamp::from(0),
+            argv: Vec::new(),
         });
     }
 

--- a/modules/process-monitor/src/lib.rs
+++ b/modules/process-monitor/src/lib.rs
@@ -115,13 +115,25 @@ pub mod pulsar {
                     },
                     ProcessEvent::Exec {
                         ref filename,
-                        argc: _,
-                        argv: _,
-                    } => TrackerUpdate::Exec {
-                        pid: event.pid,
-                        image: filename.to_string(),
-                        timestamp: event.timestamp,
-                    },
+                        argc,
+                        ref argv,
+                    } => {
+                        let argv = extract_parameters(argv);
+                        if argv.len() != argc as usize {
+                            log::warn!(
+                                "argc ({}) doens't match argv ({:?}) for {}",
+                                argc,
+                                argv,
+                                event.pid
+                            )
+                        }
+                        TrackerUpdate::Exec {
+                            pid: event.pid,
+                            image: filename.to_string(),
+                            timestamp: event.timestamp,
+                            argv,
+                        }
+                    }
                     ProcessEvent::Exit { .. } => TrackerUpdate::Exit {
                         pid: event.pid,
                         timestamp: event.timestamp,

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -118,6 +118,9 @@ pub enum Payload {
     Bind {
         address: SocketAddr,
     },
+    Listen {
+        address: SocketAddr,
+    },
     Connect {
         destination: SocketAddr,
     },

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -107,6 +107,8 @@ pub enum Payload {
     },
     Exec {
         filename: String,
+        argc: usize,
+        argv: Vec<String>,
     },
     Exit {
         exit_code: u32,

--- a/pulsar-core/src/pdk/module.rs
+++ b/pulsar-core/src/pdk/module.rs
@@ -188,6 +188,7 @@ impl ModuleSender {
                     image,
                     ppid,
                     fork_time,
+                    argv: _,
                 }) => {
                     header.image = image;
                     header.parent = ppid.as_raw();

--- a/pulsar-core/src/pdk/process_tracker.rs
+++ b/pulsar-core/src/pdk/process_tracker.rs
@@ -208,7 +208,11 @@ impl ProcessTracker {
                         exit_time: None,
                         original_image: self.get_image(ppid, timestamp),
                         exec_changes: BTreeMap::new(),
-                        argv: Vec::new(),
+                        argv: self
+                            .data
+                            .get(&ppid)
+                            .map(|parent| parent.argv.clone())
+                            .unwrap_or_default(),
                     },
                 );
                 if let Some(pending_updates) = self.pending_updates.remove(&pid) {


### PR DESCRIPTION
This implements #65 and #66

I'm not particularly happy about the performance implications of the arguments modification.

1. We're copying much data on every event to userspace, even if the arguments are smaller.
    We should optimize these by using some variable size data structure.

2. We're cloning the arguments when getting info from process tracker https://github.com/Exein-io/pulsar/blob/c39136b3ad8862cb1882833fec2d78bbba958df7/pulsar-core/src/pdk/process_tracker.rs#L269
  Even when most of the times we'll discard them: https://github.com/Exein-io/pulsar/blob/c39136b3ad8862cb1882833fec2d78bbba958df7/pulsar-core/src/pdk/module.rs#L184-L191
  We could (A) add a different method, complicating the API or (B) use an Arc. What do you think?


## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
