### PR TITLE
refactor: update to clap 4. Closes #72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,13 +229,28 @@ checksum = "ac2bd7a1eb07da9ac757c923f69373deb7bc2ba5efc951b873bcb5e693992dca"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.7",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.13",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -252,10 +267,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -846,7 +883,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc195aab5b803465bf614a5a4765741abce6c8d64e7d8ca57acd2923661fba9f"
 dependencies = [
- "clap",
+ "clap 3.2.13",
  "crossbeam-channel",
  "rayon",
  "termcolor",
@@ -1156,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1198,7 +1235,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "bpf-common",
- "clap",
+ "clap 4.0.13",
  "comfy-table",
  "engine-api",
  "env_logger",

--- a/pulsar/Cargo.toml
+++ b/pulsar/Cargo.toml
@@ -19,7 +19,7 @@ env_logger = "0.9.0"
 libc = "0.2"
 log = "0.4.14"
 anyhow = "1.0.53"
-clap = { version = "3.0.12", features = ["derive"] }
+clap = { version = "4.0.13", features = ["derive"] }
 lazy_static = "1.4.0"
 serde = "1.0.136"
 semver = { version = "1.0.4", features = ["serde"] }

--- a/pulsar/src/cli/pulsar.rs
+++ b/pulsar/src/cli/pulsar.rs
@@ -50,7 +50,7 @@ pub struct Config {
     pub module: Option<String>,
 
     /// Set/Update configuration for a specified module: syntax is 'MODULE.KEY=VALUE'
-    #[clap(long, short, parse(try_from_str=parse_mc_key_value), value_name = "MODULE.KEY=VALUE")]
+    #[clap(long, short, value_parser=parse_mc_key_value, value_name = "MODULE.KEY=VALUE")]
     pub set: Option<ModuleConfigKV>,
 }
 


### PR DESCRIPTION
# Clap v4

update clap to v4

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
