### PR TITLE
Add protocol field to bind and connect

### DIFF
--- a/modules/network-monitor/probes.bpf.c
+++ b/modules/network-monitor/probes.bpf.c
@@ -37,6 +37,7 @@ struct bind_event {
 
 struct connect_event {
   struct address destination;
+  u8 proto;
 };
 
 struct accept_event {
@@ -292,6 +293,7 @@ static __always_inline void on_socket_connect(void *ctx, struct socket *sock,
   event->timestamp = bpf_ktime_get_ns();
 
   copy_sockaddr(address, &event->connect.destination, false);
+  event->connect.proto = get_sock_protocol(BPF_CORE_READ(sock, sk));
 
   bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
                         sizeof(struct network_event));

--- a/modules/network-monitor/probes.bpf.c
+++ b/modules/network-monitor/probes.bpf.c
@@ -195,7 +195,7 @@ static __always_inline void copy_skc_source(struct sock_common *sk,
     break;
   }
   default:
-    LOG_DEBUG("ignored sockaddr famility %d", family);
+    LOG_DEBUG("ignored sockaddr family %d", family);
   }
 }
 
@@ -219,7 +219,7 @@ static __always_inline void copy_skc_dest(struct sock_common *sk,
     break;
   }
   default:
-    LOG_DEBUG("ignored sockaddr famility %d", family);
+    LOG_DEBUG("ignored sockaddr family %d", family);
   }
 }
 

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -127,6 +127,7 @@ pub enum Payload {
     },
     Connect {
         destination: Host,
+        is_tcp: bool,
     },
     Accept {
         source: Host,

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -120,6 +120,7 @@ pub enum Payload {
     },
     Bind {
         address: Host,
+        is_tcp: bool,
     },
     Listen {
         address: Host,


### PR DESCRIPTION
Extract protocol type for bind and connect events.

Listen, accept and close are TCP only, so I've added no field there.

Fix https://github.com/Exein-io/pulsar/issues/79

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
