### PR TITLE
Strip BPF probes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
           submodules: recursive
 
       - name: Install musl-gcc
-        run: sudo apt install -y musl-tools
+        run: sudo apt install -y musl-tools llvm
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
           submodules: recursive
 
       - name: Install musl-gcc
-        run: sudo apt install -y musl-tools
+        run: sudo apt install -y musl-tools llvm
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -61,7 +61,7 @@ jobs:
           submodules: recursive
 
       - name: Install musl-gcc
-        run: sudo apt install -y musl-tools
+        run: sudo apt install -y musl-tools llvm
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,11 @@
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
-pre-build = ["apt install -y clang"]
+pre-build = ["apt install -y clang llvm"]
 
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
-pre-build = ["apt install -y clang"]
+pre-build = ["apt install -y clang llvm"]
 
 [target.riscv64gc-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:main"
-pre-build = ["apt install -y clang"]
+pre-build = ["apt install -y clang llvm"]

--- a/bpf-common/src/builder.rs
+++ b/bpf-common/src/builder.rs
@@ -18,6 +18,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
         Err(_) => String::from(CLANG_DEFAULT),
     };
 
+    // Compile
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let include_path = PathBuf::from(INCLUDE_PATH);
     let status = Command::new(clang)
@@ -46,7 +47,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
         Err("Failed to compile eBPF program")?;
     }
 
-    //
+    // Strip debug symbols
     let status = Command::new(LLVM_STRIP)
         .arg("-g")
         .arg(out_object)


### PR DESCRIPTION
# Strip BPF probes

Add `llvm-strip`  command to strip debug symbols but leaving BTF

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
