### PR TITLE
Custom container for cross builds

### DIFF
--- a/.cross/README.md
+++ b/.cross/README.md
@@ -1,0 +1,5 @@
+# Cross containers
+
+These containers are used in conjunction with [cross](https://github.com/cross-rs/cross) to build Pulsar in a reproducible way without worrying about system dependencies. 
+
+Containers are based on the default [cross containers](https://github.com/orgs/cross-rs/packages) built from `Ubuntu 20.04 LTS`, with the addition of `Clang/LLVM 15`.

--- a/.cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/.cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-15 /usr/bin/llvm-strip

--- a/.cross/aarch64-unknown-linux-musl.Dockerfile
+++ b/.cross/aarch64-unknown-linux-musl.Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-15 /usr/bin/llvm-strip

--- a/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
+++ b/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:main
+RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-15 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/.cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-15 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-musl.Dockerfile
+++ b/.cross/x86_64-unknown-linux-musl.Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
+RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-15 /usr/bin/llvm-strip

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,19 +1,14 @@
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
-pre-build = ["apt install -y clang llvm"]
+dockerfile = ".cross/aarch64-unknown-linux-gnu.Dockerfile"
 
 [target.aarch64-unknown-linux-musl]
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
-pre-build = ["apt install -y clang llvm"]
+dockerfile = ".cross/aarch64-unknown-linux-musl.Dockerfile"
 
 [target.riscv64gc-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:main"
-pre-build = ["apt install -y clang llvm"]
+dockerfile = ".cross/riscv64gc-unknown-linux-gnu.Dockerfile"
 
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main"
-pre-build = ["apt install -y clang llvm"]
+dockerfile = ".cross/x86_64-unknown-linux-gnu.Dockerfile"
 
 [target.x86_64-unknown-linux-musl]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:main"
-pre-build = ["apt install -y clang llvm"]
+dockerfile = ".cross/x86_64-unknown-linux-musl.Dockerfile"

--- a/vagrant/fedora36/Vagrantfile
+++ b/vagrant/fedora36/Vagrantfile
@@ -1,0 +1,7 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure("2") do |config|
+    config.vm.box = "bento/fedora-36"
+    config.vm.box_version = "202206.03.0"
+end
+  


### PR DESCRIPTION
# Custom container for cross builds

Added a custom container for builds using `cross` with updated `clang/llvm` (v15), the default `clang/llvm` (v10) seems to have problem generating the BPF bytecode.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
