### PR TITLE
fix clippy 1.65 warnings

### DIFF
--- a/bpf-common/src/builder.rs
+++ b/bpf-common/src/builder.rs
@@ -26,7 +26,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
         .arg(format!("-I{}", include_path.join(&arch).to_string_lossy()))
         .arg("-g")
         .arg("-O2")
-        .args(&["-target", "bpf"])
+        .args(["-target", "bpf"])
         .arg("-c")
         .arg(format!(
             "-D__TARGET_ARCH_{}",

--- a/modules/network-monitor/src/lib.rs
+++ b/modules/network-monitor/src/lib.rs
@@ -402,7 +402,7 @@ pub mod test_suite {
         let bind_addr: SocketAddr = bind_addr.parse().unwrap();
         TestRunner::with_ebpf(program)
             .run(|| {
-                let _listener = TcpListener::bind(&bind_addr).unwrap();
+                let _listener = TcpListener::bind(bind_addr).unwrap();
             })
             .await
             .expect_event(event_check!(
@@ -418,7 +418,7 @@ pub mod test_suite {
             let bind_addr: SocketAddr = "127.0.0.1:18001".parse().unwrap();
             TestRunner::with_ebpf(program)
                 .run(|| {
-                    let _listener = UdpSocket::bind(&bind_addr).unwrap();
+                    let _listener = UdpSocket::bind(bind_addr).unwrap();
                 })
                 .await
                 .expect_event(event_check!(
@@ -440,7 +440,7 @@ pub mod test_suite {
 
     async fn run_connect_test(dest: &str) -> TestReport {
         let dest: SocketAddr = dest.parse().unwrap();
-        let _listener = TcpListener::bind(&dest).unwrap();
+        let _listener = TcpListener::bind(dest).unwrap();
         TestRunner::with_ebpf(program)
             .run(|| {
                 TcpStream::connect(dest).unwrap();
@@ -458,7 +458,7 @@ pub mod test_suite {
         TestCase::new("connect_udp", async {
             let bind_addr1: SocketAddr = "127.0.0.1:18021".parse().unwrap();
             let bind_addr2: SocketAddr = "127.0.0.1:18022".parse().unwrap();
-            let _listener = UdpSocket::bind(&bind_addr1).unwrap();
+            let _listener = UdpSocket::bind(bind_addr1).unwrap();
             TestRunner::with_ebpf(program)
                 .run(|| {
                     UdpSocket::bind(bind_addr2)
@@ -489,7 +489,7 @@ pub mod test_suite {
         let bind_addr: SocketAddr = bind_addr.parse().unwrap();
         TestRunner::with_ebpf(program)
             .run(|| {
-                let _listener = TcpListener::bind(&bind_addr).unwrap();
+                let _listener = TcpListener::bind(bind_addr).unwrap();
             })
             .await
             .expect_event(event_check!(
@@ -512,7 +512,7 @@ pub mod test_suite {
         let mut source = dest;
         TestRunner::with_ebpf(program)
             .run(|| {
-                let listener = TcpListener::bind(&dest).unwrap();
+                let listener = TcpListener::bind(dest).unwrap();
                 let handle =
                     std::thread::spawn(move || TcpStream::connect(dest).unwrap().local_addr());
                 listener.accept().unwrap();
@@ -571,7 +571,7 @@ pub mod test_suite {
             .run(|| match proto {
                 Proto::UDP => {
                     source.set_port(dest.port() + 1);
-                    let receiver = UdpSocket::bind(&dest).unwrap();
+                    let receiver = UdpSocket::bind(dest).unwrap();
                     std::thread::spawn(move || {
                         let s = UdpSocket::bind(source).unwrap();
                         s.connect(dest).unwrap();
@@ -581,7 +581,7 @@ pub mod test_suite {
                     assert_eq!(receiver.recv_from(&mut buf).unwrap(), (msg.len(), source));
                 }
                 Proto::TCP => {
-                    let listener = TcpListener::bind(&dest).unwrap();
+                    let listener = TcpListener::bind(dest).unwrap();
                     let t = std::thread::spawn(move || {
                         let mut client = TcpStream::connect(dest).unwrap();
                         client.write_all(&msg).unwrap();
@@ -625,7 +625,7 @@ pub mod test_suite {
         let dest: SocketAddr = dest.parse().unwrap();
         let mut source = dest;
         let mut expected_pid = Pid::from_raw(0);
-        let listener = TcpListener::bind(&dest).unwrap();
+        let listener = TcpListener::bind(dest).unwrap();
         // The on_tcp_set_state hook may be called by a process different from
         // the original creator the connection. This happens for example if it
         // receives a SIGKILL. We test this to make sure we're still emitting

--- a/modules/process-monitor/src/filtering/maps.rs
+++ b/modules/process-monitor/src/filtering/maps.rs
@@ -92,7 +92,7 @@ impl RuleMap {
     /// Fill the map with a list of rules
     pub(crate) fn install(&mut self, rules: &Vec<Rule>) -> Result<()> {
         for rule in rules {
-            let value: u8 = if rule.with_children { 1 } else { 0 };
+            let value: u8 = u8::from(rule.with_children);
             self.map
                 .insert(rule.image, value, 0)
                 .with_context(|| format!("Error inserting rule in {}", self.name))?;

--- a/modules/rules-engine/src/engine.rs
+++ b/modules/rules-engine/src/engine.rs
@@ -109,7 +109,7 @@ struct RuleFile {
 impl RuleFile {
     pub fn from(path: &Path) -> Result<Self, PulsarEngineError> {
         log::debug!("loading rule {}", path.display());
-        let body = fs::read_to_string(&path).map_err(|error| PulsarEngineError::RuleLoading {
+        let body = fs::read_to_string(path).map_err(|error| PulsarEngineError::RuleLoading {
             name: path.display().to_string(),
             error,
         })?;

--- a/pulsar/src/pulsard/config.rs
+++ b/pulsar/src/pulsard/config.rs
@@ -152,7 +152,7 @@ struct ModuleConfigUpdate<'a> {
 
 /// Open configuration ini file, update the given config and save it to disk
 fn update_file_config(config_file: &PathBuf, updates: &[ModuleConfigUpdate]) -> Result<()> {
-    let mut conf = ini::Ini::load_from_file(&config_file)
+    let mut conf = ini::Ini::load_from_file(config_file)
         .with_context(|| format!("Error loading configuration from {:?}", &config_file))?;
 
     for ModuleConfigUpdate { module, key, value } in updates {
@@ -160,7 +160,7 @@ fn update_file_config(config_file: &PathBuf, updates: &[ModuleConfigUpdate]) -> 
         log::debug!("Changing configuration {}.{}={}", module, key, value);
     }
 
-    conf.write_to_file(&config_file)
+    conf.write_to_file(config_file)
         .with_context(|| format!("Error writing to {:?}", &config_file))?;
 
     Ok(())

--- a/validatron/src/engine.rs
+++ b/validatron/src/engine.rs
@@ -59,10 +59,10 @@ impl<T: ValidatronVariant> Engine<T> {
 
         log::debug!("Loaded {} rules", compiled_conditions.len());
 
-        let mut by_variant = HashMap::new();
+        let mut by_variant: HashMap<usize, Vec<CompiledRule<T>>> = HashMap::new();
 
         for (variant_num, c) in compiled_conditions {
-            by_variant.entry(variant_num).or_insert(Vec::new()).push(c);
+            by_variant.entry(variant_num).or_default().push(c);
         }
 
         Ok(Self(by_variant))


### PR DESCRIPTION
# fix clippy 1.65 warnings

small fixes around to address clippy warnings

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
