### PR TITLE
Fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Pulsar is built with a modular design that makes it easy to adapt the core archi
 ## Quickstart
 
 > **Warning**  
-> A kernel 5.5 or higher with BPF and BTF enabled is required. Visit the official Pulsar website for the full [requirements](https://pulsar.sh/docs/requirements) and [installation options](https://pulsar.sh/docs/installation) available.
+> A kernel 5.5 or higher with BPF and BTF enabled is required. Visit the official Pulsar website for the full [requirements](https://pulsar.sh/docs/faq/kernel-requirements/) and [installation options](https://pulsar.sh/docs/getting-started/installation) available.
 
 To download and install Pulsar, run the following in your terminal:
 

--- a/modules/file-system-monitor/README.md
+++ b/modules/file-system-monitor/README.md
@@ -38,7 +38,7 @@ pulsar config --set file-system-monitor.elf_check_enabled=false
 
 ## Testing
 
-You can try this module using the [probe binary](../../pulsar/bin/probe.rs):
+You can try this module using the [probe binary](../../pulsar/src/bin/probe.rs):
 
 ```sh
 cargo xtask probe file-system-monitor

--- a/modules/network-monitor/README.md
+++ b/modules/network-monitor/README.md
@@ -36,7 +36,7 @@ pulsar config --set network-monitor.enabled=false
 
 ## Testing
 
-You can try this module using the [probe binary](../../pulsar/bin/probe.rs):
+You can try this module using the [probe binary](../../pulsar/src/bin/probe.rs):
 
 ```sh
 cargo xtask probe network-monitor

--- a/modules/process-monitor/README.md
+++ b/modules/process-monitor/README.md
@@ -45,7 +45,7 @@ pulsar config --set process-monitor.targets_children=/usr/sbin/sshd
 
 ## Testing
 
-You can try this module using the [probe binary](../../pulsar/bin/probe.rs):
+You can try this module using the [probe binary](../../pulsar/src/bin/probe.rs):
 
 ```sh
 cargo xtask probe process-monitor


### PR DESCRIPTION
The latest website changes resulted in some dead links.
I also fixed the path reference to `probe.rs`

I used this command for highlighting the issues:
```
markdown-link-check -q $(git ls-files '*.md')
```
I would be cool to enable these checks in CI.