### PR TITLE
fix(rule_engine): add check for events already marked as threats

### DIFF
--- a/modules/rules-engine/src/engine.rs
+++ b/modules/rules-engine/src/engine.rs
@@ -54,9 +54,12 @@ impl PulsarEngine {
     }
 
     pub fn process(&self, event: &Event) {
-        self.internal.engine.run(event, |rule| {
-            emit_event(&self.internal.sender, event, &rule.name)
-        })
+        // Run the engine only on non threat events to avoid creating loops
+        if event.header().threat.is_none() {
+            self.internal.engine.run(event, |rule| {
+                emit_event(&self.internal.sender, event, &rule.name)
+            })
+        }
     }
 }
 

--- a/modules/rules-engine/src/lib.rs
+++ b/modules/rules-engine/src/lib.rs
@@ -35,8 +35,7 @@ async fn rules_engine_task(
             // handle pulsar message
             event = receiver.recv() => {
                 let event = event?;
-                    engine.process(&event)
-
+                engine.process(&event)
             },
         }
     }


### PR DESCRIPTION
Fix  #123  by changing the rule engine to check if threat info are already present in events before starting its analysis