### PR TITLE
Add scripts to ease development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .vscode
 .idea
 *.swp
+
+compile_commands.json
+.cache

--- a/scripts/check_bytecode.sh
+++ b/scripts/check_bytecode.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# Compile an eBPF source and print its bytecode. This is useful to understand
+# verifier issues.
+
+# Print commands
+set -x
+# Stop on error
+set -e
+
+# Compile eBPF to /tmp/obj.o
+clang -g -O2 -c $1 -o /tmp/obj.o -target bpf -D__TARGET_ARCH_x86 -I bpf-common/include/ -I bpf-common/include/x86_64/
+sleep 1
+llvm-objdump -S --no-show-raw-insn /tmp/obj.o

--- a/scripts/gen_compile_commands.sh
+++ b/scripts/gen_compile_commands.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+# Run to build a compile_commands.json, which useful for auto-completion engines 
+(
+first=1
+echo -n "["
+for source in */*/*.bpf.c
+do
+  if test $first -eq 1
+  then
+    first=0
+  else
+    echo ","
+  fi
+  workspace=$(realpath $(dirname ${source}))
+  dir=$(realpath $(dirname ${source}))
+  workspace=$(realpath "${dir}/../..")
+  name=$(basename ${source})
+  echo "{"
+  echo "  \"directory\": \"${dir}\","
+  echo "  \"file\": \"${name}\","
+  echo "  \"arguments\": ["
+	echo "    \"/usr/bin/clang\","
+	echo "    \"-I${workspace}/bpf-common/include/\","
+	echo "    \"-I${workspace}/bpf-common/include/x86_64/\","
+	echo "    \"-g\","
+	echo "    \"-O2\","
+	echo "    \"-D__TARGET_ARCH_x86\","
+	echo "    \"-c\","
+	echo "    \"-o /tmp/file.o\","
+	echo "    \"${name}\""
+  echo "  ]"
+  echo -n "}"
+done
+echo "]"
+) | tee compile_commands.json


### PR DESCRIPTION
# Development scripts

## `./scripts/check_bytecode.sh`

Add a script which compiles a probe and uses llvm-objdump to output
its annotated bytecode. This is useful during development to understand
what compiler optimizations are happening and possible verifier
complaints.

Example:
```
./scripts/check_bytecode.sh modules/file-system-monitor/probe.bpf.c
```

## `./scripts/gen_compile_commands.sh`

Added a script which generates a `compile_commands.json` for all
eBPF sources. This is useful for auto-completion and error reporting.

We can't simply add the file to git because it contains absolute paths.

This was tested with vscode and the clangd language server of nvim.

Example:
```
./scripts/gen_compile_commands.sh
```

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
