### PR TITLE
new(filtering): whitelist current executable

### DIFF
--- a/bpf-common/src/program.rs
+++ b/bpf-common/src/program.rs
@@ -100,13 +100,13 @@ pub enum ProgramError {
     ProgramLoadError {
         program: String,
         #[source]
-        program_error: aya::programs::ProgramError,
+        program_error: Box<aya::programs::ProgramError>,
     },
     #[error("failed program attach {program}")]
     ProgramAttachError {
         program: String,
         #[source]
-        program_error: aya::programs::ProgramError,
+        program_error: Box<aya::programs::ProgramError>,
     },
     #[error(transparent)]
     MapError(#[from] aya::maps::MapError),
@@ -231,11 +231,11 @@ impl ProgramType {
     fn attach(&self, bpf: &mut Bpf, btf: &Btf) -> Result<(), ProgramError> {
         let load_err = |program_error| ProgramError::ProgramLoadError {
             program: self.to_string(),
-            program_error,
+            program_error: Box::new(program_error),
         };
         let attach_err = |program_error| ProgramError::ProgramAttachError {
             program: self.to_string(),
-            program_error,
+            program_error: Box::new(program_error),
         };
         match self {
             ProgramType::TracePoint(section, tracepoint) => {

--- a/modules/process-monitor/README.md
+++ b/modules/process-monitor/README.md
@@ -22,6 +22,7 @@ all other modules.
 |`targets_children`|image list|List of processes to track (extended to children)|
 |`whitelist`|image list|List of processes to ignore|
 |`whitelist_children`|image list|List of processes to ignore (extended to children)|
+|`ignore_self`|bool|Add the Pulsar executable to whitelist_children|
 
 Default configuration:
 
@@ -34,6 +35,7 @@ targets=
 targets_children=
 whitelist=
 whitelist_children=
+ignore_self=true
 ```
 
 For example, to limit Pulsar analisys to SSH connections with:

--- a/modules/process-monitor/src/filtering/config.rs
+++ b/modules/process-monitor/src/filtering/config.rs
@@ -10,6 +10,7 @@ pub(crate) struct Config {
     pub(crate) pid_targets: Vec<PidRule>,
     pub(crate) targets: Vec<Rule>,
     pub(crate) whitelist: Vec<Rule>,
+    pub(crate) ignore_self: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -60,6 +61,7 @@ impl TryFrom<&ModuleConfig> for Config {
             pid_targets,
             targets,
             whitelist,
+            ignore_self: config.with_default("ignore_self", true)?,
         })
     }
 }

--- a/modules/process-monitor/src/filtering/initializer.rs
+++ b/modules/process-monitor/src/filtering/initializer.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
+use std::{os::unix::prelude::OsStringExt, time::Duration};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bpf_common::{aya::Bpf, Pid};
 use pulsar_core::{
     pdk::process_tracker::{ProcessTrackerHandle, TrackerUpdate},
@@ -9,9 +9,9 @@ use pulsar_core::{
 use tokio::sync::mpsc;
 
 use super::{
-    config::Config,
+    config::{Config, Rule},
     maps::InterestMap,
-    maps::{PolicyDecision, RuleMap},
+    maps::{Image, PolicyDecision, RuleMap},
     process_tree::{ProcessData, ProcessTree, PID_0},
 };
 
@@ -31,10 +31,18 @@ const INIT_TIMEOUT: Duration = Duration::from_millis(100);
 ///    because of unitialized entries.
 pub(crate) async fn setup_events_filter(
     bpf: &mut Bpf,
-    config: Config,
+    mut config: Config,
     process_tracker: &ProcessTrackerHandle,
     rx_processes: &mut mpsc::UnboundedReceiver<TrackerUpdate>,
 ) -> Result<()> {
+    // Add a rule to ignore the pulsar executable itself
+    if config.ignore_self {
+        match whitelist_for_current_process() {
+            Ok(rule) => config.whitelist.push(rule),
+            Err(err) => log::error!("Failed to add current process to whitelist: {:?}", err),
+        }
+    }
+
     // setup targets map
     let mut target_map = RuleMap::target(bpf)?;
     target_map.clear()?;
@@ -95,7 +103,6 @@ struct Initializer {
     interest_map: InterestMap,
     cache: std::collections::HashMap<Pid, PolicyDecision>,
     config: Config,
-    my_pid: Pid,
 }
 
 impl Initializer {
@@ -103,15 +110,12 @@ impl Initializer {
         // clear whitelist map
         let mut interest_map = InterestMap::load(bpf)?;
         interest_map.clear()?;
-
         let cache = Default::default();
-        let my_pid = Pid::from_raw(std::process::id() as i32);
 
         Ok(Self {
             interest_map,
             cache,
             config,
-            my_pid,
         })
     }
 
@@ -163,13 +167,6 @@ impl Initializer {
                 decision.children_interesting = true;
             }
         };
-        // make sure to ignore pulsard
-        if process.pid == self.my_pid {
-            decision = PolicyDecision {
-                interesting: false,
-                children_interesting: false,
-            };
-        }
         if decision.interesting {
             log::debug!("tracking {} {}", process.pid, process.image);
         }
@@ -177,4 +174,15 @@ impl Initializer {
         self.interest_map.set(process.pid, decision)?;
         Ok(())
     }
+}
+
+/// Return a rule which whitelists the current executable.
+/// This is needed to avoid loops where pulsar events generate further events.
+fn whitelist_for_current_process() -> Result<Rule> {
+    let pulsar_exec = std::fs::read_link(&format!("/proc/{}/exe", std::process::id()))
+        .context("Failed to read current process executable name")?;
+    Ok(Rule {
+        image: Image::try_from(pulsar_exec.into_os_string().into_vec())?,
+        with_children: true,
+    })
 }

--- a/modules/process-monitor/src/filtering/initializer.rs
+++ b/modules/process-monitor/src/filtering/initializer.rs
@@ -179,7 +179,7 @@ impl Initializer {
 /// Return a rule which whitelists the current executable.
 /// This is needed to avoid loops where pulsar events generate further events.
 fn whitelist_for_current_process() -> Result<Rule> {
-    let pulsar_exec = std::fs::read_link(format!("/proc/{}/exe", std::process::id()))
+    let pulsar_exec = std::fs::read_link("/proc/self/exe")
         .context("Failed to read current process executable name")?;
     Ok(Rule {
         image: Image::try_from(pulsar_exec.into_os_string().into_vec())?,

--- a/modules/process-monitor/src/filtering/initializer.rs
+++ b/modules/process-monitor/src/filtering/initializer.rs
@@ -179,7 +179,7 @@ impl Initializer {
 /// Return a rule which whitelists the current executable.
 /// This is needed to avoid loops where pulsar events generate further events.
 fn whitelist_for_current_process() -> Result<Rule> {
-    let pulsar_exec = std::fs::read_link(&format!("/proc/{}/exe", std::process::id()))
+    let pulsar_exec = std::fs::read_link(format!("/proc/{}/exe", std::process::id()))
         .context("Failed to read current process executable name")?;
     Ok(Rule {
         image: Image::try_from(pulsar_exec.into_os_string().into_vec())?,

--- a/modules/process-monitor/src/filtering/maps.rs
+++ b/modules/process-monitor/src/filtering/maps.rs
@@ -134,22 +134,39 @@ pub(crate) struct Image(pub(crate) [u8; MAX_IMAGE_LEN]);
 // We must explicitly mark Image as a plain old data which can be safely memcopied by aya.
 unsafe impl bpf_common::aya::Pod for Image {}
 
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum InvalidImage {
+    #[error("process image coming from string must be ascii")]
+    NotAscii,
+    #[error("process image must be smaller than {MAX_IMAGE_LEN}")]
+    TooLong,
+}
+
+impl TryFrom<Vec<u8>> for Image {
+    type Error = InvalidImage;
+
+    fn try_from(mut data: Vec<u8>) -> Result<Self, Self::Error> {
+        if data.len() > MAX_IMAGE_LEN {
+            return Err(InvalidImage::TooLong);
+        }
+        data.resize(MAX_IMAGE_LEN, 0);
+        let mut image_array = [0; MAX_IMAGE_LEN];
+        image_array.clone_from_slice(&data[..]);
+        Ok(Image(image_array))
+    }
+}
+
 impl FromStr for Image {
-    type Err = String;
+    type Err = InvalidImage;
 
     fn from_str(image: &str) -> Result<Self, Self::Err> {
         if !image.is_ascii() {
-            Err("process image must be ascii".to_string())
+            Err(InvalidImage::NotAscii)
         } else if image.len() >= MAX_IMAGE_LEN {
-            Err(format!(
-                "process image must be smaller than {MAX_IMAGE_LEN}"
-            ))
+            Err(InvalidImage::TooLong)
         } else {
-            let mut image_vec: Vec<u8> = image.bytes().collect();
-            image_vec.resize(MAX_IMAGE_LEN, 0);
-            let mut image_array = [0; MAX_IMAGE_LEN];
-            image_array.clone_from_slice(&image_vec[..]);
-            Ok(Image(image_array))
+            let data: Vec<u8> = image.bytes().collect();
+            Image::try_from(data)
         }
     }
 }


### PR DESCRIPTION
Fix #128 by whitelisting the current process path instead of the current PID. This allows to ignore the client CLI executable. Failing to ignore it would lead to loops of events, see issue #128 for more details.

Add option `process-monitor.ignore_self`, which can be used to disable this default behaviour.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
