### PR TITLE
Track parent changes

### DIFF
--- a/modules/process-monitor/src/filtering/initializer.rs
+++ b/modules/process-monitor/src/filtering/initializer.rs
@@ -82,7 +82,7 @@ pub(crate) async fn setup_events_filter(
                 TrackerUpdate::Exec { pid, image, .. } => {
                     initializer.update(process_tree.exec(*pid, image)?)?
                 }
-                TrackerUpdate::Exit { .. } => {}
+                TrackerUpdate::Exit { .. } | TrackerUpdate::SetNewParent { .. } => {}
             };
             process_tracker.update(update);
         }

--- a/modules/process-monitor/src/lib.rs
+++ b/modules/process-monitor/src/lib.rs
@@ -124,7 +124,10 @@ pub mod pulsar {
                         pid: event.pid,
                         timestamp: event.timestamp,
                     },
-                    ProcessEvent::ChangeParent { .. } => todo!(),
+                    ProcessEvent::ChangeParent { ppid } => TrackerUpdate::SetNewParent {
+                        pid: event.pid,
+                        ppid,
+                    },
                 });
             }),
         )
@@ -170,7 +173,9 @@ pub mod pulsar {
                     argv: extract_parameters(argv.bytes(&buffer)?).into(),
                 },
                 ProcessEvent::Exit { exit_code } => Payload::Exit { exit_code },
-                ProcessEvent::ChangeParent { .. } => todo!(),
+                ProcessEvent::ChangeParent { ppid } => Payload::ChangeParent {
+                    ppid: ppid.as_raw(),
+                },
             })
         }
     }

--- a/pulsar-core/src/event.rs
+++ b/pulsar-core/src/event.rs
@@ -210,6 +210,9 @@ pub enum Payload {
     Exit {
         exit_code: u32,
     },
+    ChangeParent {
+        ppid: i32,
+    },
     SyscallActivity {
         #[validatron(skip)]
         histogram: Vec<u64>,
@@ -276,6 +279,7 @@ impl fmt::Display for Payload {
             Payload::Fork { ppid } => write!(f,"Fork {{ ppid: {ppid} }}"),
             Payload::Exec { filename, argc, argv } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv} }}"),
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
+            Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
             Payload::SyscallActivity { .. } => write!(f,"Syscall Activity"),
             Payload::Bind { address, is_tcp } => write!(f,"Bind {{ address: {address}, is_tcp: {is_tcp} }}"),
             Payload::Listen { address } => write!(f,"Listen {{ address: {address} }}"),  

--- a/pulsar-core/src/pdk/process_tracker.rs
+++ b/pulsar-core/src/pdk/process_tracker.rs
@@ -37,6 +37,10 @@ pub enum TrackerUpdate {
         image: String,
         argv: Vec<String>,
     },
+    SetNewParent {
+        pid: Pid,
+        ppid: Pid,
+    },
     Exit {
         pid: Pid,
         timestamp: Timestamp,
@@ -243,6 +247,13 @@ impl ProcessTracker {
                     // if exit arrived before the fork, we save the event as pending
                     log::debug!("(exit) Process {pid} not found in process tree, saving for later");
                     self.pending_updates.entry(pid).or_default().push(update);
+                }
+            }
+            TrackerUpdate::SetNewParent { pid, ppid } => {
+                if let Some(p) = self.data.get_mut(&pid) {
+                    p.ppid = ppid;
+                } else {
+                    log::warn!("{ppid} is the new parent of {pid}, but we couldn't find it")
                 }
             }
         }


### PR DESCRIPTION
# Track parent changes

Fix #106
 
## Implementation

Add a `ChangeParent { ppid: Pid }` event to process monitor, which can be used to intercept when the parent of a process changes.

It works by adding to a temporary map all the orphans of dead processes. This is done by the `collect_orphans` call at the end of `sched_process_exit`. Than we wait for their parent to be changed by the kernel and emit events for the new parents. Ideally we would have done it on the exit of the exit syscall, unfortunately that syscall never returns as the process has died. The kernel will just schedule the next process. For this reason we'll do this check on sched_switch.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
