### PR TITLE
misc(probe): remove Display from inner events

### DIFF
--- a/bpf-common/ProbeTutorial.md
+++ b/bpf-common/ProbeTutorial.md
@@ -99,18 +99,12 @@ pub async fn program(
 }
 
 const NAME_MAX: usize = 264;
+#[derive(Debug)]
 #[repr(C)]
 pub enum EventT {
     FileCreated { filename: [u8; NAME_MAX] },
 }
 
-impl fmt::Display for EventT {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            EventT::FileCreated { filename } => write!(f, "{}", filename),
-        }
-    }
-}
 ```
 
 The central part of the module is the `program` function, which:

--- a/modules/file-system-monitor/src/lib.rs
+++ b/modules/file-system-monitor/src/lib.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use bpf_common::{
     aya::include_bytes_aligned, feature_autodetect::lsm::lsm_supported, parsing::BufferIndex,
     program::BpfContext, test_runner::ComparableField, BpfSender, Program, ProgramBuilder,
@@ -48,6 +46,7 @@ pub async fn program(
     Ok(program)
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub enum FsEvent {
     FileCreated {
@@ -75,35 +74,6 @@ pub enum FsEvent {
         source: BufferIndex<str>,
         destination: BufferIndex<str>,
     },
-}
-
-impl fmt::Display for FsEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FsEvent::FileCreated { filename } => write!(f, "created {:?}", filename),
-            FsEvent::FileDeleted { filename } => write!(f, "deleted {:?}", filename),
-            FsEvent::DirCreated { filename } => write!(f, "created dir {:?}", filename),
-            FsEvent::DirDeleted { filename } => write!(f, "deleted dir {:?}", filename),
-            FsEvent::FileOpened { filename, flags } => {
-                write!(f, "open {:?} ({})", filename, flags)
-            }
-            FsEvent::FileLink {
-                source,
-                destination,
-                hard_link,
-            } => write!(
-                f,
-                "{} {:?} -> {:?}",
-                if *hard_link { "hardlink" } else { "symlink" },
-                source,
-                destination
-            ),
-            FsEvent::FileRename {
-                source,
-                destination,
-            } => write!(f, "rename {:?} -> {:?}", source, destination),
-        }
-    }
 }
 
 pub mod pulsar {

--- a/modules/process-monitor/src/lib.rs
+++ b/modules/process-monitor/src/lib.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use anyhow::Context;
 use bpf_common::{
     aya::include_bytes_aligned, parsing::BufferIndex, program::BpfContext, BpfSender, Pid, Program,
@@ -43,22 +41,6 @@ pub enum ProcessEvent {
     Exit {
         exit_code: u32,
     },
-}
-
-impl fmt::Display for ProcessEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProcessEvent::Fork { ppid } => write!(f, "forked from {}", ppid),
-            ProcessEvent::Exec {
-                filename,
-                argc,
-                argv,
-            } => {
-                write!(f, "exec {:?} (argc: {}, argv: {:?})", filename, argc, argv)
-            }
-            ProcessEvent::Exit { exit_code } => write!(f, "exit({})", exit_code),
-        }
-    }
 }
 
 fn extract_parameters(argv: &[u8]) -> Vec<String> {


### PR DESCRIPTION
Remove the need to implement Display on inner types of modules:
- Since it had no access to buffer, it was mostly useless as it lacked information.
- Replace its use with IntoPayload for the `probe` binary
- Replace its use with Debug for the test-suite

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
