### PR TITLE
fix(xtask): fix regressions

### DIFF
--- a/vagrant/static.sh
+++ b/vagrant/static.sh
@@ -15,7 +15,7 @@ excluded="--exclude threat-response-lua"
 
 export CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
 cargo build --bin pulsar-exec ${features}
-cargo build --bin test-suite ${features}
+cargo build --package test-suite
 
 for vagrantfile in vagrant/*/Vagrantfile
 do

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,10 +26,10 @@ fn main() {
     let opts = Options::parse();
 
     let ret = match opts.command {
-        Command::Pulsard(opts) => run_with_sudo("pulsar-exec", &["pulsard"], opts),
-        Command::Pulsar(opts) => run_with_sudo("pulsar-exec", &["pulsar"], opts),
-        Command::Probe(opts) => run_with_sudo("probe", &[], opts),
-        Command::Test(opts) => run_with_sudo("test-suite", &[], opts),
+        Command::Pulsard(opts) => run_with_sudo("pulsar", "pulsar-exec", &["pulsard"], opts),
+        Command::Pulsar(opts) => run_with_sudo("pulsar", "pulsar-exec", &["pulsar"], opts),
+        Command::Probe(opts) => run_with_sudo("pulsar", "probe", &[], opts),
+        Command::Test(opts) => run_with_sudo("test-suite", "test-suite", &[], opts),
     };
 
     if let Err(e) = ret {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,10 +26,10 @@ fn main() {
     let opts = Options::parse();
 
     let ret = match opts.command {
-        Command::Pulsard(opts) => run_with_sudo("pulsar", "pulsar-exec", &["pulsard"], opts),
-        Command::Pulsar(opts) => run_with_sudo("pulsar", "pulsar-exec", &["pulsar"], opts),
-        Command::Probe(opts) => run_with_sudo("pulsar", "probe", &[], opts),
-        Command::Test(opts) => run_with_sudo("test-suite", "test-suite", &[], opts),
+        Command::Pulsard(opts) => run_with_sudo("pulsar-exec", &["pulsard"], opts),
+        Command::Pulsar(opts) => run_with_sudo("pulsar-exec", &["pulsar"], opts),
+        Command::Probe(opts) => run_with_sudo("probe", &[], opts),
+        Command::Test(opts) => run_with_sudo("test-suite", &[], opts),
     };
 
     if let Err(e) = ret {

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -8,26 +8,31 @@ pub struct Options {
     #[clap(long)]
     pub release: bool,
     /// Arguments to pass to your application
-    #[clap(name = "args", last = true)]
+    #[clap(name = "args")]
     pub run_args: Vec<String>,
 }
 
 /// Build the binary
-fn build(binary: &str, opts: &Options) -> Result<()> {
+fn build(package: &str, binary: &str, opts: &Options) -> Result<()> {
     let sh = Shell::new()?;
-
-    let mut build_cmd = format!("cargo build --bin {binary}");
-    if opts.release {
-        build_cmd.push_str(" --release")
-    }
-    cmd!(sh, "{build_cmd}").run()?;
+    let cargo = std::env::var("CARGO").unwrap();
+    let args = if opts.release {
+        Some("--release")
+    } else {
+        None
+    };
+    cmd!(
+        sh,
+        "{cargo} build --package {package} --bin {binary} {args...}"
+    )
+    .run()?;
 
     Ok(())
 }
 
 /// Build and run the binary with admin privileges
-pub fn run_with_sudo(binary: &str, prefix: &[&str], opts: Options) -> Result<()> {
-    build(binary, &opts)?;
+pub fn run_with_sudo(package: &str, binary: &str, prefix: &[&str], opts: Options) -> Result<()> {
+    build(package, binary, &opts)?;
 
     let sh = Shell::new()?;
 

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -13,7 +13,7 @@ pub struct Options {
 }
 
 /// Build the binary
-fn build(package: &str, binary: &str, opts: &Options) -> Result<()> {
+fn build(binary: &str, opts: &Options) -> Result<()> {
     let sh = Shell::new()?;
     let cargo = std::env::var("CARGO").unwrap();
     let args = if opts.release {
@@ -21,18 +21,14 @@ fn build(package: &str, binary: &str, opts: &Options) -> Result<()> {
     } else {
         None
     };
-    cmd!(
-        sh,
-        "{cargo} build --package {package} --bin {binary} {args...}"
-    )
-    .run()?;
+    cmd!(sh, "{cargo} build --workspace --bin {binary} {args...}").run()?;
 
     Ok(())
 }
 
 /// Build and run the binary with admin privileges
-pub fn run_with_sudo(package: &str, binary: &str, prefix: &[&str], opts: Options) -> Result<()> {
-    build(package, binary, &opts)?;
+pub fn run_with_sudo(binary: &str, prefix: &[&str], opts: Options) -> Result<()> {
+    build(binary, &opts)?;
 
     let sh = Shell::new()?;
 


### PR DESCRIPTION
Fixed a couple of regressions in xtask execution:
- After the new workspace setup, we need to specify the package for the non main crates (eg. test-suite).
- The `cmd!` macro parses its format string: the old code was putting the arguments in the executable name.
- Remove `last` from `run_args` so we don't need the `--` separator.

As an improvement, we're now taking the cargo binary location from the CARGO env variable.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
