### PR TITLE
Fix network-monitor TCP buffer-index regression

### DIFF
--- a/crates/bpf-common/include/buffer.bpf.h
+++ b/crates/bpf-common/include/buffer.bpf.h
@@ -77,7 +77,7 @@ static void buffer_append_str(struct buffer *buffer, struct buffer_index *index,
 
   int r = bpf_core_read_str(&((char *)buffer->buffer)[pos], len, source);
   if (r <= 0) {
-    LOG_ERROR("redding failure: %d", r);
+    LOG_ERROR("reading failure: %d", r);
     return;
   }
   // LOG_DEBUG("New buffer: %s (+%d)", buffer->buffer, r);
@@ -101,7 +101,7 @@ static void buffer_append_user_memory(struct buffer *buffer,
   int r = bpf_core_read_user(&((char *)buffer->buffer)[pos],
                              len & HALF_BUFFER_MASK, source);
   if (r < 0) {
-    LOG_ERROR("redding failure: %d", r);
+    LOG_ERROR("reading failure: %d", r);
     return;
   }
   // LOG_DEBUG("New buffer: %s (+%d)", buffer->buffer, r);

--- a/crates/modules/network-monitor/probes.bpf.c
+++ b/crates/modules/network-monitor/probes.bpf.c
@@ -339,6 +339,8 @@ static __always_inline void on_socket_sendmsg(void *ctx, struct socket *sock,
   // Copy data only for UDP events since we want to intercept DNS requests
   if (proto == PROTO_UDP) {
     read_iovec(&event->buffer, &event->send, iov_base);
+  } else {
+    event->send.data.len = 0;
   }
 
   copy_skc_source(&sk->__sk_common, &event->send.source);
@@ -417,6 +419,8 @@ static __always_inline void do_recvmsg(void *ctx, long ret) {
   // Copy data only for UDP events since we want to intercept DNS replies
   if (proto == PROTO_UDP) {
     read_iovec(&event->buffer, &event->recv, iov_base);
+  } else {
+    event->recv.data.len = 0;
   }
 
   u16 family = BPF_CORE_READ(sk, __sk_common.skc_family);

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -191,10 +191,10 @@ pub mod pulsar {
     };
 
     pub fn module() -> PulsarModule {
-        PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), syscall_monitor_task)
+        PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), network_monitor_task)
     }
 
-    async fn syscall_monitor_task(
+    async fn network_monitor_task(
         ctx: ModuleContext,
         mut shutdown: ShutdownSignal,
     ) -> Result<CleanExit, ModuleError> {
@@ -305,7 +305,7 @@ pub mod pulsar {
         let data = data
             .bytes(&event.buffer)
             .map_err(|err| {
-                log::error!("Error getting message: {}", err);
+                log::error!("[dns] Error getting message: {}", err);
             })
             .ok()?;
 


### PR DESCRIPTION
In network-monitor, the send and receive event have a BufferIndex inside
the data field, which contains the actual message. This is only used for
UDP messages, since we use it to intercept DNS.

The change to dynamic message sizes using buffer and indexes introduced
a regression in the TCP path: we weren't setting the data.len to 0,
resulting in a garbage len being sent. The buffer was empty though, so
we got a lot of warnings. This explains why the errors didn't start
right away when starting pulsar (first, we needed to send or receive the
first UDP message) and kept coming up afterwards (the len was set in the
UDP probe and never reset until the next UDP message)

Fix https://github.com/Exein-io/pulsar/issues/139

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
