### PR TITLE
update aya now supporting btf kind enum64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.11.0"
-source = "git+https://github.com/aya-rs/aya?rev=4cc0ea09e0f95ab7f4eaae34ed0163f529296733#4cc0ea09e0f95ab7f4eaae34ed0163f529296733"
+source = "git+https://github.com/aya-rs/aya?rev=22d79312f7f5d8afd97dfaa42d3cd063206772e3#22d79312f7f5d8afd97dfaa42d3cd063206772e3"
 dependencies = [
  "aya-obj",
  "bitflags",
@@ -133,7 +133,7 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?rev=4cc0ea09e0f95ab7f4eaae34ed0163f529296733#4cc0ea09e0f95ab7f4eaae34ed0163f529296733"
+source = "git+https://github.com/aya-rs/aya?rev=22d79312f7f5d8afd97dfaa42d3cd063206772e3#22d79312f7f5d8afd97dfaa42d3cd063206772e3"
 dependencies = [
  "bytes",
  "log",

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -12,7 +12,7 @@ test-suite = ["test-utils"]
 test-utils = []
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", rev = "4cc0ea09e0f95ab7f4eaae34ed0163f529296733", features = ["async_tokio"] }
+aya = { git = "https://github.com/aya-rs/aya", rev = "22d79312f7f5d8afd97dfaa42d3cd063206772e3", features = ["async_tokio"] }
 bytes = "1.3.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Fix #85 updating aya
## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
