### PR TITLE
Better modules version 

### DIFF
--- a/crates/bpf-common/ProbeTutorial.md
+++ b/crates/bpf-common/ProbeTutorial.md
@@ -267,7 +267,7 @@ pub mod pulsar {
     pub fn file_created() -> PulsarModule {
         PulsarModule::new(
             "file-created",
-            Version::new(0, 0, 1),
+            Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
             file_created_task,
         )
     }

--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -16,7 +16,11 @@ use pulsar_core::{
 const MODULE_NAME: &str = "desktop-notifier";
 
 pub fn module() -> PulsarModule {
-    PulsarModule::new(MODULE_NAME, Version::new(0, 1, 0), desktop_nitifier_task)
+    PulsarModule::new(
+        MODULE_NAME,
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        desktop_nitifier_task,
+    )
 }
 
 async fn desktop_nitifier_task(

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -94,7 +94,11 @@ pub mod pulsar {
     use tokio::{fs::File, io::AsyncReadExt};
 
     pub fn module() -> PulsarModule {
-        PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), fs_monitor_task)
+        PulsarModule::new(
+            MODULE_NAME,
+            Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            fs_monitor_task,
+        )
     }
 
     async fn fs_monitor_task(

--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -6,7 +6,11 @@ use pulsar_core::pdk::{
 const MODULE_NAME: &str = "logger";
 
 pub fn module() -> PulsarModule {
-    PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), logger_task)
+    PulsarModule::new(
+        MODULE_NAME,
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        logger_task,
+    )
 }
 
 async fn logger_task(

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -191,7 +191,11 @@ pub mod pulsar {
     };
 
     pub fn module() -> PulsarModule {
-        PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), network_monitor_task)
+        PulsarModule::new(
+            MODULE_NAME,
+            Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            network_monitor_task,
+        )
     }
 
     async fn network_monitor_task(

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -72,7 +72,11 @@ pub mod pulsar {
     use tokio::sync::mpsc;
 
     pub fn module() -> PulsarModule {
-        PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), process_monitor_task)
+        PulsarModule::new(
+            MODULE_NAME,
+            Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            process_monitor_task,
+        )
     }
 
     async fn process_monitor_task(

--- a/crates/modules/rules-engine/src/lib.rs
+++ b/crates/modules/rules-engine/src/lib.rs
@@ -14,7 +14,11 @@ const DEFAULT_RULES_PATH: &str = "/var/lib/pulsar/rules";
 const MODULE_NAME: &str = "rules-engine";
 
 pub fn module() -> PulsarModule {
-    PulsarModule::new(MODULE_NAME, Version::new(0, 4, 0), rules_engine_task)
+    PulsarModule::new(
+        MODULE_NAME,
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        rules_engine_task,
+    )
 }
 
 async fn rules_engine_task(

--- a/crates/pulsar-core/src/pdk/mod.rs
+++ b/crates/pulsar-core/src/pdk/mod.rs
@@ -33,7 +33,7 @@
 //! pub fn my_module() -> PulsarModule {
 //!     PulsarModule::new(
 //!         "my-module",
-//!         Version::new(0, 0, 1),
+//!         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
 //!         my_module_task,
 //!     )
 //! }

--- a/examples/pulsar-embedded-agent/proxy_module.rs
+++ b/examples/pulsar-embedded-agent/proxy_module.rs
@@ -13,7 +13,7 @@ pub fn module(tx_ctx: oneshot::Sender<ModuleContext>) -> PulsarModule {
     let tx_ctx = Arc::new(Mutex::new(Some(tx_ctx)));
     PulsarModule::new(
         MODULE_NAME,
-        Version::new(0, 1, 0),
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         move |ctx, mut shutdown| {
             let tx_ctx = tx_ctx.clone();
             async move {

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -9,7 +9,11 @@ use pulsar_core::pdk::{
 const MODULE_NAME: &str = "my-custom-module";
 
 pub fn module() -> PulsarModule {
-    PulsarModule::new(MODULE_NAME, Version::new(0, 1, 0), module_task)
+    PulsarModule::new(
+        MODULE_NAME,
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        module_task,
+    )
 }
 
 async fn module_task(

--- a/src/pulsard/config.rs
+++ b/src/pulsard/config.rs
@@ -92,7 +92,7 @@ impl PulsarConfig {
             .subscribe()
     }
 
-    /// Get module configuration. This is intended to be used when a single access is enought.
+    /// Get module configuration. This is intended to be used when a single access is enough.
     pub fn get_module_config(&self, module: &str) -> Option<ModuleConfig> {
         self.inner
             .lock()
@@ -102,7 +102,7 @@ impl PulsarConfig {
             .map(|watch_sender| watch_sender.borrow().clone())
     }
 
-    /// Get all configurations. This is intended to be used when a single access is enought.
+    /// Get all configurations. This is intended to be used when a single access is enough.
     pub fn get_configs(&self) -> Vec<(String, ModuleConfig)> {
         self.inner
             .lock()


### PR DESCRIPTION
# Better modules version

Currently the version in pulsar modules is a fixed string inside every crate and it needs an update at every version change. this pr replaces the fixed string with the crate version. 

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
