### PR TITLE
Fix 141 startup warnings in ebpf programs

### DIFF
--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -18,7 +18,6 @@ pub async fn program(
     // If LSM eBPF programs is not supported, we'll attach to the same kernel
     // functions, but using kprobes.
     if lsm_supported().await {
-        log::info!("Loading LSM programs");
         builder = builder
             .lsm("path_mknod")
             .lsm("path_unlink")
@@ -29,7 +28,6 @@ pub async fn program(
             .lsm("path_link")
             .lsm("path_symlink");
     } else {
-        log::info!("LSM programs not supported. Falling back to kprobes");
         builder = builder
             .kprobe("security_path_mknod")
             .kprobe("security_path_unlink")

--- a/src/pulsard/mod.rs
+++ b/src/pulsard/mod.rs
@@ -64,7 +64,15 @@ pub async fn pulsar_daemon_run(
     server_handle.stop().await;
 
     log::info!("Terminating Pulsar Daemon...");
-    drop(pulsar_daemon);
+    for module in pulsar_daemon.modules().await {
+        if let Err(err) = pulsar_daemon.stop(module.name.clone()).await {
+            log::warn!(
+                "Module {} didn't respond to shutdown signal. Forcing shutdown.\n{:?}",
+                module.name,
+                err
+            )
+        }
+    }
 
     Ok(())
 }

--- a/src/pulsard/module_manager.rs
+++ b/src/pulsard/module_manager.rs
@@ -134,8 +134,14 @@ impl ModuleManager {
                     let (tx_shutdown, task) = self.running_task.take().unwrap();
                     tx_shutdown.send_signal();
                     let result = task.await;
-                    log::info!("Module {} exited: {:?}", self.task_launcher.name(), result);
-                    // TODO: use this result and report errors
+                    match result {
+                        Ok(()) => log::info!("Module {} exited", self.task_launcher.name()),
+                        Err(err) => log::warn!(
+                            "Module {} exit failure: {:?}",
+                            self.task_launcher.name(),
+                            err
+                        ),
+                    }
                     self.status = ModuleStatus::Stopped;
                     Ok(())
                 } else {


### PR DESCRIPTION
Fix #141:
- Wait for the perf event map to be opened before starting to generate events
- Shut down all modules before pulsar exits. This is also a partial fix for #7

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
