### PR TITLE
Use bpf_loop when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,9 +952,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -997,14 +997,16 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1572,6 +1574,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-fd = "0.3.0"
 log = "0.4"
 anyhow = "1"
-nix = "0.24.0"
+nix = { version = "0.26.2", features = ["fs"] }
 sys-mount = {version = "1.5.1", default-features = false}
 procfs = { version = "0.14.2", default-features = false }
 libc = "0.2"

--- a/crates/bpf-common/include/common.bpf.h
+++ b/crates/bpf-common/include/common.bpf.h
@@ -10,6 +10,7 @@
 #define LOG_LEVEL_ERROR 1
 #define LOG_LEVEL_DEBUG 2
 const volatile int log_level = 0;
+const volatile int LINUX_KERNEL_VERSION;
 
 // NOTE: bpf_printk supports up to 3 arguments, while these LOG_ macros
 // allow only up to 2 arguments since one is used by the probe name.

--- a/crates/bpf-common/include/loop.bpf.h
+++ b/crates/bpf-common/include/loop.bpf.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// The LOOP macro allows to iterate using the `bpf_loop` helper function when
+// available (kernel >= 5.17) and falls back on a regular loop when the kernel
+// is too old.
+//
+// The macro takes:
+// - the maximum number of iterations
+// - a callback function, which will be called until it returns 1.
+// - a pointer which will be passed to the context, which can be used to keep
+//   state across iterations.
+
+// Note: callback_fn must be declared as `static __always_inline` to satisfy the
+// verifier. For some reason, having this double call to the same non-inline
+// function seems to cause issues.
+#define LOOP(max_iterations, callback_fn, ctx)                                 \
+  if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 17, 0)) {                      \
+    bpf_loop(max_iterations, callback_fn, ctx, 0);                             \
+  } else {                                                                     \
+    _Pragma("unroll") for (int i = 0; i < max_iterations; i++) {               \
+      if (callback_fn(i, ctx) == 1)                                            \
+        break;                                                                 \
+    }                                                                          \
+  }

--- a/crates/bpf-common/src/builder.rs
+++ b/crates/bpf-common/src/builder.rs
@@ -11,6 +11,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/common.bpf.h");
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/buffer.bpf.h");
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/output.bpf.h");
+    println!("cargo:rerun-if-changed={INCLUDE_PATH}/loop.bpf.h");
 
     let out_path = PathBuf::from(env::var("OUT_DIR")?);
     let out_object = out_path.join("probe.bpf.o");

--- a/crates/bpf-common/src/feature_autodetect/kernel_version.rs
+++ b/crates/bpf-common/src/feature_autodetect/kernel_version.rs
@@ -1,0 +1,136 @@
+//! Extract kernel version from the currently running system.
+//! Code ported from libbpf.
+
+use anyhow::{Context, Result};
+use nix::fcntl::AtFlags;
+use nix::sys::utsname::uname;
+use nix::unistd::{faccessat, AccessFlags};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct KernelVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl KernelVersion {
+    pub fn autodetect() -> Result<KernelVersion> {
+        // On Ubuntu LINUX_VERSION_CODE doesn't correspond to info.release,
+        // but Ubuntu provides /proc/version_signature file, as described at
+        // https://ubuntu.com/kernel, with an example contents below, which we
+        // can use to get a proper LINUX_VERSION_CODE.
+        //
+        //   Ubuntu 5.4.0-12.15-generic 5.4.8
+        //
+        // In the above, 5.4.8 is what kernel is actually expecting, while
+        // uname() call will return 5.4.0 in info.release.
+        if faccessat(
+            None,
+            "/proc/version_signature",
+            AccessFlags::R_OK,
+            // TODO: switch to AT_EACCESS once this patch is merged and released:
+            // https://github.com/nix-rust/nix/pull/1995
+            // As a workaround we're using AT_REMOVEDIR, which has the same value on linux
+            AtFlags::AT_REMOVEDIR,
+        )
+        .is_ok()
+        {
+            if let Ok(value) = std::fs::read_to_string("/proc/version_signature") {
+                return Self::parse_version_signature(&value);
+            }
+        }
+        Self::parse_uname_release(
+            uname()
+                .context("Getting kernel version calling uname() failed")?
+                .release()
+                .to_str()
+                .context("Kernel version from uname contained invalid characters")?,
+        )
+    }
+
+    /// Parse release fields from the format "%*s %*s %d.%d.%d\n"
+    fn parse_version_signature(value: &str) -> Result<KernelVersion> {
+        let parse = |value: &str| -> Option<KernelVersion> {
+            let version_items: Vec<&str> = value
+                .split_whitespace()
+                .skip(2)
+                .next()?
+                .split('.')
+                .collect();
+            if let [major, minor, patch] = version_items[..] {
+                Some(KernelVersion {
+                    major: major.parse().ok()?,
+                    minor: minor.parse().ok()?,
+                    patch: patch.parse().ok()?,
+                })
+            } else {
+                None
+            }
+        };
+        parse(value).with_context(|| format!("Invalid version_signature format: {value}"))
+    }
+
+    /// Parse release fields from the format "%d.%d.%d"
+    fn parse_uname_release(value: &str) -> Result<KernelVersion> {
+        let parse = |value: &str| -> Option<KernelVersion> {
+            let version_items: Vec<&str> = value.split('.').collect();
+            if let [major, minor, patch] = version_items[..] {
+                Some(KernelVersion {
+                    major: major.parse().ok()?,
+                    minor: minor.parse().ok()?,
+                    patch: patch.parse().ok()?,
+                })
+            } else {
+                None
+            }
+        };
+        parse(value).with_context(|| format!("Invalid version_signature format: {value}"))
+    }
+
+    /// Encode to a single i32 as the kernel macro KERNEL_VERSION()
+    pub fn as_i32(&self) -> i32 {
+        ((self.major << 16) + (self.minor << 8) + self.patch.max(255)) as i32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_signature() {
+        assert_eq!(
+            KernelVersion::parse_version_signature("Ubuntu 5.4.0-12.15-generic 5.4.8\n").unwrap(),
+            KernelVersion {
+                major: 5,
+                minor: 4,
+                patch: 8
+            }
+        );
+    }
+
+    #[test]
+    fn parse_uname_release() {
+        assert_eq!(
+            KernelVersion::parse_uname_release("5.17.4").unwrap(),
+            KernelVersion {
+                major: 5,
+                minor: 17,
+                patch: 4
+            }
+        );
+    }
+
+    #[test]
+    fn int_conversion() {
+        assert_eq!(
+            KernelVersion {
+                major: 5,
+                minor: 17,
+                patch: 4
+            }
+            .as_i32(),
+            332287
+        );
+    }
+}

--- a/crates/bpf-common/src/feature_autodetect/mod.rs
+++ b/crates/bpf-common/src/feature_autodetect/mod.rs
@@ -1,4 +1,5 @@
 //! This module checks what features are supported by the runnig kernel
+pub mod kernel_version;
 pub mod lsm;
 
 #[cfg(feature = "test-suite")]

--- a/crates/bpf-common/src/program.rs
+++ b/crates/bpf-common/src/program.rs
@@ -18,7 +18,7 @@ use bytes::{Buf, Bytes, BytesMut};
 use thiserror::Error;
 use tokio::{sync::watch, task::JoinError};
 
-use crate::{time::Timestamp, BpfSender, Pid};
+use crate::{feature_autodetect::kernel_version::KernelVersion, time::Timestamp, BpfSender, Pid};
 
 const PERF_HEADER_SIZE: usize = 4;
 const PINNED_MAPS_PATH: &str = "/sys/fs/bpf/pulsar";
@@ -44,6 +44,8 @@ pub struct BpfContext {
     perf_pages: usize,
     /// Log level for eBPF print statements
     log_level: BpfLogLevel,
+    /// Kernel version
+    kernel_version: KernelVersion,
 }
 
 #[derive(Clone)]
@@ -71,6 +73,17 @@ impl BpfContext {
             log::warn!("The default value {PERF_PAGES_DEFAULT} will be used.");
             perf_pages = PERF_PAGES_DEFAULT;
         }
+        let kernel_version = match KernelVersion::autodetect() {
+            Ok(version) => version,
+            Err(err) => {
+                log::warn!("Error identifying kernel version {err:?}. Assuming kernel 5.0.4");
+                KernelVersion {
+                    major: 5,
+                    minor: 0,
+                    patch: 4,
+                }
+            }
+        };
         // aya doesn't support specifying from userspace wether or not to pin maps.
         // As a hack we always pin and delete the folder on shutdown.
         let pinning_path = match pinning {
@@ -84,6 +97,7 @@ impl BpfContext {
             perf_pages,
             pinning_path,
             log_level,
+            kernel_version,
         })
     }
 }
@@ -187,6 +201,7 @@ impl ProgramBuilder {
                 .map_pin_path(&self.ctx.pinning_path)
                 .btf(Some(btf.as_ref()))
                 .set_global("log_level", &(self.ctx.log_level as i32))
+                .set_global("LINUX_KERNEL_VERSION", &self.ctx.kernel_version.as_i32())
                 .load(&self.probe)?;
             for program in self.programs {
                 program.attach(&mut bpf, &btf)?;

--- a/crates/modules/file-system-monitor/Cargo.toml
+++ b/crates/modules/file-system-monitor/Cargo.toml
@@ -12,7 +12,7 @@ test-suite = ["bpf-common/test-utils"]
 bpf-common = { path = "../../bpf-common" }
 pulsar-core = { path = "../../pulsar-core" }
 
-nix = "0.24.0"
+nix = "0.26.2"
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
 

--- a/crates/modules/network-monitor/Cargo.toml
+++ b/crates/modules/network-monitor/Cargo.toml
@@ -14,7 +14,7 @@ pulsar-core = { path = "../../pulsar-core" }
 
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
-nix = "0.24.0"
+nix = "0.26.2"
 dns-parser = "0.8.0"
 
 [build-dependencies]

--- a/crates/modules/process-monitor/Cargo.toml
+++ b/crates/modules/process-monitor/Cargo.toml
@@ -13,7 +13,7 @@ bpf-common = { path = "../../bpf-common" }
 pulsar-core = { path = "../../pulsar-core" }
 
 tokio = { version = "1", features = ["full"] }
-nix = "0.24.0"
+nix = "0.26.2"
 log = "0.4"
 thiserror = "1"
 which = { version = "4.2.5", optional = true }

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -239,6 +239,7 @@ int BPF_PROG(sched_switch) {
   }
   pending->dead_parent = 0;
   int i;
+  // TODO: use LOOP
   for (i = 0; i < MAX_ORPHANS; i = i + 1) {
     struct task_struct *orphan = pending->orphans[i];
     if (orphan == NULL)

--- a/crates/pulsar-core/Cargo.toml
+++ b/crates/pulsar-core/Cargo.toml
@@ -17,4 +17,4 @@ semver = { version = "1.0.4", features = ["serde"] }
 anyhow = "1.0.53"
 log = "0.4"
 thiserror = "1.0.30"
-nix = "0.24.0"
+nix = "0.26.2"


### PR DESCRIPTION
Fix #142 by using `bpf_loop`:
- Add kernel version autodetection
- Sent the kernel version as a global variable into the eBPF
- Added a LOOP macro which uses `bpf_loop` when available (kernel >= 5.17) and falls back to an unrolled loop if not.  
- Replaced the loop inside `file-system-monitor` with the new code. 

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
