### PR TITLE
Small fix and change

### DIFF
--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -77,18 +77,18 @@ pub mod terminal {
 
     pub fn print_event(event: &Event) {
         let header = event.header();
-        let time = DateTime::<Utc>::from(header.timestamp);
+        let time = DateTime::<Utc>::from(header.timestamp).format("%Y-%m-%dT%TZ");
         let image = &header.image;
         let pid = &header.pid;
         let payload = event.payload();
 
         if let Some(Threat { source, info }) = &event.header().threat {
             println!(
-                "[{time} \x1b[1;30;43mTHREAT\x1b[0m {image} ({pid})] [{source} - {info}] {payload}"
+                "[{time} \x1b[1;30;43mTHREAT\x1b[0m  {image} ({pid})] [{source} - {info}] {payload}"
             )
         } else {
             let source = &header.source;
-            println!("[{time} \x1b[1;30;46mEVENT\x1b[0m {image} ({pid})] [{source}] {payload}")
+            println!("[{time} \x1b[1;30;46mEVENT\x1b[0m  {image} ({pid})] [{source}] {payload}")
         }
     }
 }


### PR DESCRIPTION
- align event datetime print to env_logger
- add check for already used map in bpf program 

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
