### PR TITLE
Fix bpf_loop regression on kernel < 5.13

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-crates/bpf-common/include/*/vmlinux* linguist-vendored
-crates/bpf-common/include/bpf/* linguist-vendored
+crates/bpf-builder/include/*/vmlinux* linguist-vendored
+crates/bpf-builder/include/bpf/* linguist-vendored

--- a/crates/bpf-builder/include/loop.bpf.h
+++ b/crates/bpf-builder/include/loop.bpf.h
@@ -13,7 +13,7 @@
 // Note: callback_fn must be declared as `static __always_inline` to satisfy the
 // verifier. For some reason, having this double call to the same non-inline
 // function seems to cause issues.
-#ifdef NOLOOP
+#ifdef FEATURE_NO_FN_POINTERS
 // On kernel <= 5.13 taking the address of a function results in a verifier
 // error, even if inside a dead-code elimination branch.
 #define LOOP(max_iterations, callback_fn, ctx)                                 \

--- a/crates/bpf-builder/src/lib.rs
+++ b/crates/bpf-builder/src/lib.rs
@@ -9,7 +9,7 @@ static INCLUDE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/include");
 // Given the filename of an eBPF program source code, compile it to OUT_DIR.
 // We'll build two versions:
 // - `probe_full.bpf.o`: will contain the full version
-// - `probe_noloop.bpf.o`: will contain a version with the FEATURE_NO_FN_POINTERS constant
+// - `probe_no_fn_ptr.bpf.o`: will contain a version with the FEATURE_NO_FN_POINTERS constant
 //   defined. This version should be loaded on kernel < 5.13, where taking
 //   the address of a static function would result in a verifier error.
 //   See
@@ -28,7 +28,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
         .context("Error compiling full version")?;
     compile(
         probe,
-        out_path.join("probe_noloop.bpf.o"),
+        out_path.join("probe_no_fn_ptr.bpf.o"),
         &["-DFEATURE_NO_FN_POINTERS"],
     )
     .context("Error compiling no-loop version")?;

--- a/crates/bpf-builder/src/lib.rs
+++ b/crates/bpf-builder/src/lib.rs
@@ -1,11 +1,20 @@
 use std::{env, path::PathBuf, process::Command, string::String};
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 
 static CLANG_DEFAULT: &str = "clang";
 static LLVM_STRIP: &str = "llvm-strip";
 static INCLUDE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/include");
 
+// Given the filename of an eBPF program source code, compile it to OUT_DIR.
+// We'll build two versions:
+// - `probe_full.bpf.o`: will contain the full version
+// - `probe_noloop.bpf.o`: will contain a version with the NOLOOP constant
+//   defined. This version should be loaded on kernel < 5.13, where taking
+//   the address of a static function would result in a verifier error.
+//   See
+//   - https://github.com/Exein-io/pulsar/issues/158
+//   - https://github.com/torvalds/linux/commit/69c087ba6225b574afb6e505b72cb75242a3d844
 pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={probe}");
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/common.bpf.h");
@@ -14,14 +23,17 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/loop.bpf.h");
 
     let out_path = PathBuf::from(env::var("OUT_DIR")?);
-    let out_object = out_path.join("probe.bpf.o");
 
-    let clang = match env::var("CLANG") {
-        Ok(val) => val,
-        Err(_) => String::from(CLANG_DEFAULT),
-    };
+    compile(probe, out_path.join("probe_full.bpf.o"), &[])
+        .context("Error compiling full version")?;
+    compile(probe, out_path.join("probe_noloop.bpf.o"), &["-DNOLOOP"])
+        .context("Error compiling no-loop version")?;
 
-    // Compile
+    Ok(())
+}
+
+fn compile(probe: &str, out_object: PathBuf, extra_args: &[&str]) -> anyhow::Result<()> {
+    let clang = env::var("CLANG").unwrap_or_else(|_| String::from(CLANG_DEFAULT));
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let include_path = PathBuf::from(INCLUDE_PATH);
     let status = Command::new(clang)
@@ -41,6 +53,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
                 _ => arch.clone(),
             }
         ))
+        .args(extra_args)
         .arg(probe)
         .arg("-o")
         .arg(&out_object)
@@ -48,7 +61,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
         .context("Failed to execute clang")?;
 
     if !status.success() {
-        Err("Failed to compile eBPF program")?;
+        bail!("Failed to compile eBPF program");
     }
 
     // Strip debug symbols
@@ -59,7 +72,7 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
         .context("Failed to execute llvm-strip")?;
 
     if !status.success() {
-        Err("Failed strip eBPF program")?;
+        bail!("Failed strip eBPF program");
     }
 
     Ok(())

--- a/crates/bpf-builder/src/lib.rs
+++ b/crates/bpf-builder/src/lib.rs
@@ -9,7 +9,7 @@ static INCLUDE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/include");
 // Given the filename of an eBPF program source code, compile it to OUT_DIR.
 // We'll build two versions:
 // - `probe_full.bpf.o`: will contain the full version
-// - `probe_noloop.bpf.o`: will contain a version with the NOLOOP constant
+// - `probe_noloop.bpf.o`: will contain a version with the FEATURE_NO_FN_POINTERS constant
 //   defined. This version should be loaded on kernel < 5.13, where taking
 //   the address of a static function would result in a verifier error.
 //   See
@@ -26,8 +26,12 @@ pub fn build(probe: &str) -> Result<(), Box<dyn std::error::Error>> {
 
     compile(probe, out_path.join("probe_full.bpf.o"), &[])
         .context("Error compiling full version")?;
-    compile(probe, out_path.join("probe_noloop.bpf.o"), &["-DNOLOOP"])
-        .context("Error compiling no-loop version")?;
+    compile(
+        probe,
+        out_path.join("probe_noloop.bpf.o"),
+        &["-DFEATURE_NO_FN_POINTERS"],
+    )
+    .context("Error compiling no-loop version")?;
 
     Ok(())
 }

--- a/crates/bpf-common/ProbeTutorial.md
+++ b/crates/bpf-common/ProbeTutorial.md
@@ -78,7 +78,7 @@ The module implementation in Rust is also relatively short.
 use std::fmt;
 
 use bpf_common::{
-    aya::include_bytes_aligned, program::BpfContext, BpfSender, Program,
+    aya::program::BpfContext, BpfSender, Program,
     ProgramBuilder, ProgramError,
 };
 
@@ -86,10 +86,11 @@ pub async fn program(
     ctx: BpfContext,
     sender: impl BpfSender<EventT>,
 ) -> Result<Program, ProgramError> {
+    let binary = ebpf_program!(&ctx);
     let program = ProgramBuilder::new(
         ctx,
         "file_created",
-        include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe.bpf.o")).into(),
+        binary,
     )
     .kprobe("security_inode_create")
     .start()

--- a/crates/bpf-common/src/bump_memlock_rlimit.rs
+++ b/crates/bpf-common/src/bump_memlock_rlimit.rs
@@ -1,0 +1,14 @@
+use anyhow::{anyhow, bail, Result};
+
+/// Bumps the rlimit for memlock up to full capacity.
+/// This is required to load even reasonably sized eBPF maps until kernel 5.11.
+pub fn bump_memlock_rlimit() -> Result<()> {
+    let rlimit = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
+        bail!(anyhow!(std::io::Error::last_os_error()).context("Failed to increase rlimit"))
+    }
+    Ok(())
+}

--- a/crates/bpf-common/src/feature_autodetect/lsm.rs
+++ b/crates/bpf-common/src/feature_autodetect/lsm.rs
@@ -22,7 +22,8 @@ pub fn lsm_supported() -> bool {
 }
 
 const PATH: &str = "/sys/kernel/security/lsm";
-static TEST_LSM_PROBE: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe.bpf.o"));
+static TEST_LSM_PROBE: &[u8] =
+    include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe_full.bpf.o"));
 
 fn try_load() -> Result<()> {
     // Check if LSM enabled

--- a/crates/bpf-common/src/lib.rs
+++ b/crates/bpf-common/src/lib.rs
@@ -6,10 +6,12 @@ pub mod test_runner;
 #[cfg(debug_assertions)]
 pub mod trace_pipe;
 
+mod bump_memlock_rlimit;
 pub mod parsing;
 pub mod time;
 
 pub use bpf_sender::{BpfSender, BpfSenderWrapper};
+pub use bump_memlock_rlimit::bump_memlock_rlimit;
 pub use program::{Program, ProgramBuilder, ProgramError};
 
 pub use aya;

--- a/crates/bpf-common/src/program.rs
+++ b/crates/bpf-common/src/program.rs
@@ -118,7 +118,7 @@ impl BpfContext {
 
 /// Return the correct version of the eBPF binary to load.
 /// On kernel >= 5.13.0 we'll load 'probe_full.bpf.o'
-/// On kernel < 5.13.0 we'll load 'probe_noloop.bpf.o'
+/// On kernel < 5.13.0 we'll load 'probe_no_fn_ptr.bpf.o'
 /// Note: Both programs are embedded in the pulsar binary. The choice is made
 /// at runtime.
 #[macro_export]
@@ -129,7 +129,7 @@ macro_rules! ebpf_program {
 
         let full = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe_full.bpf.o")).into();
         let no_loop =
-            include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe_noloop.bpf.o")).into();
+            include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe_no_fn_ptr.bpf.o")).into();
         if $ctx.kernel_version().as_i32()
             >= (KernelVersion {
                 major: 5,

--- a/crates/bpf-common/src/program.rs
+++ b/crates/bpf-common/src/program.rs
@@ -484,15 +484,6 @@ impl Program {
     }
 }
 
-#[cfg(feature = "test-utils")]
-pub fn load_test_program(probe: &[u8]) -> Result<Bpf, ProgramError> {
-    let _ = std::fs::create_dir(PINNED_MAPS_PATH);
-    let bpf = BpfLoader::new()
-        .map_pin_path(PINNED_MAPS_PATH)
-        .load(probe)?;
-    Ok(bpf)
-}
-
 #[derive(Debug)]
 pub struct BpfEvent<P> {
     pub timestamp: Timestamp,

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -1,6 +1,6 @@
 use bpf_common::{
-    aya::include_bytes_aligned, parsing::BufferIndex, program::BpfContext, BpfSender, Program,
-    ProgramBuilder, ProgramError,
+    ebpf_program, parsing::BufferIndex, program::BpfContext, BpfSender, Program, ProgramBuilder,
+    ProgramError,
 };
 
 const MODULE_NAME: &str = "file-system-monitor";
@@ -10,11 +10,8 @@ pub async fn program(
     sender: impl BpfSender<FsEvent>,
 ) -> Result<Program, ProgramError> {
     let attach_to_lsm = ctx.lsm_supported();
-    let mut builder = ProgramBuilder::new(
-        ctx,
-        MODULE_NAME,
-        include_bytes_aligned!(concat!(env!("OUT_DIR"), "/probe.bpf.o")).into(),
-    );
+    let binary = ebpf_program!(&ctx);
+    let mut builder = ProgramBuilder::new(ctx, MODULE_NAME, binary);
     // LSM hooks provide the perfet intercept point for file system operations.
     // If LSM eBPF programs is not supported, we'll attach to the same kernel
     // functions, but using kprobes.

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -187,8 +187,7 @@ pub mod pulsar {
 pub mod test_suite {
     use crate::filtering::maps::PolicyDecision;
     use bpf_common::aya::programs::RawTracePoint;
-    use bpf_common::aya::Bpf;
-    use bpf_common::program::load_test_program;
+    use bpf_common::aya::{Bpf, BpfLoader};
     use bpf_common::test_runner::{TestCase, TestReport, TestSuite};
     use bpf_common::{event_check, program::BpfEvent, test_runner::TestRunner};
     use filtering::config::Rule;
@@ -616,6 +615,12 @@ pub mod test_suite {
             false,
         )
         .unwrap();
-        load_test_program(ebpf_program!(&ctx)).unwrap()
+        const PIN_PATH: &str = "/sys/fs/bpf/process-monitor-test";
+        let _ = std::fs::create_dir(PIN_PATH);
+        let bpf = BpfLoader::new()
+            .map_pin_path(PIN_PATH)
+            .load(ebpf_program!(&ctx))
+            .unwrap();
+        bpf
     }
 }

--- a/src/pulsard/mod.rs
+++ b/src/pulsard/mod.rs
@@ -30,7 +30,7 @@ pub async fn pulsar_daemon_run(
 
     bpf_fs::check_or_mount_bpf_fs()?;
 
-    bump_memlock_rlimit()?;
+    bpf_common::bump_memlock_rlimit()?;
 
     let config = if let Some(custom_file) = &options.config_file {
         PulsarConfig::with_custom_file(custom_file)?
@@ -76,18 +76,5 @@ pub async fn pulsar_daemon_run(
         }
     }
 
-    Ok(())
-}
-
-/// Bumps the rlimit for memlock up to full capacity.
-/// This is required to load even reasonably sized eBPF maps.
-fn bump_memlock_rlimit() -> Result<()> {
-    let rlimit = libc::rlimit {
-        rlim_cur: libc::RLIM_INFINITY,
-        rlim_max: libc::RLIM_INFINITY,
-    };
-    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
-        bail!(anyhow!(std::io::Error::last_os_error()).context("Failed to increase rlimit"))
-    }
     Ok(())
 }

--- a/src/pulsard/mod.rs
+++ b/src/pulsard/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{ensure, Result};
 use bpf_common::bpf_fs;
 use engine_api::server::{self, EngineAPIContext};
 use pulsar_core::{bus::Bus, pdk::TaskLauncher};

--- a/test-suite/src/test_suite_runner.rs
+++ b/test-suite/src/test_suite_runner.rs
@@ -23,6 +23,7 @@ impl TestSuiteRunner {
         let (tx_log, mut rx_log) = mpsc::unbounded_channel();
         replace_logger(tx_log.clone());
         replace_panic_hook(tx_log);
+        bpf_common::bump_memlock_rlimit().unwrap();
         // Spawn the actual runner, which receives tests over a channel.
         let (tx_test, mut rx_test) = mpsc::channel::<TestRequest>(1);
         tokio::spawn(async move {


### PR DESCRIPTION
Fix https://github.com/Exein-io/pulsar/issues/158 by compiling and embedding two eBPF programs:
- On kernel >= 5.13 we'll use the same code as before
- On kernel < 5.13 we'll compile a version with `NOLOOP` defined.

This requires https://github.com/Exein-io/pulsar/pull/156 to be merged first.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
