### PR TITLE
fix(network-monitor): read sk_protocol as a bitfield

### DIFF
--- a/crates/modules/network-monitor/probes.bpf.c
+++ b/crates/modules/network-monitor/probes.bpf.c
@@ -204,7 +204,7 @@ static __always_inline void copy_skc_dest(struct sock_common *sk,
 }
 
 static __always_inline u16 get_sock_protocol(struct sock *sk) {
-  u16 proto = BPF_CORE_READ(sk, sk_protocol);
+  u64 proto = BPF_CORE_READ_BITFIELD_PROBED(sk, sk_protocol);
   // TODO: clean this up
   if (proto == IPPROTO_UDP) {
     return PROTO_UDP;


### PR DESCRIPTION
This fixes protocol reading (UDP vs TCP) on kernel < 5.6, where sk_protocol was a bitfield and was being incorrectly read.

See https://github.com/Exein-io/pulsar/issues/163

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
