### PR TITLE
Make sure to extract absolute file paths on exec

### DIFF
--- a/crates/bpf-builder/include/get_path.bpf.h
+++ b/crates/bpf-builder/include/get_path.bpf.h
@@ -41,7 +41,26 @@
 //     };
 //
 
-#define MAX_PATH_COMPONENTS 20
+#define MAX_PATH_COMPONENTS 100
+#define MAX_PATH_UNROLL 20
+
+// Array of path components which is kept inside `struct get_path_ctx`.
+// bpf_loop requires `get_path_ctx` to be a stack variable, but that prevents
+// us to store MAX_PATH_COMPONENTS items inside, as that's more than the allowed
+// stack space for eBPF programs. For this reason we allocate them on a
+// temporary PERCPU_ARRAY map.
+struct components {
+  u32 total_components;
+  const unsigned char *component_name[MAX_PATH_COMPONENTS];
+  u32 component_len[MAX_PATH_COMPONENTS];
+};
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, u32);
+  __type(value, struct components);
+  __uint(max_entries, 1);
+} components_map SEC(".maps");
 
 struct get_path_ctx {
   // Output of get_path_str
@@ -52,26 +71,35 @@ struct get_path_ctx {
   struct path current;
 
   // Internal list of path components, from dentry to the root
-  const unsigned char *component_name[MAX_PATH_COMPONENTS];
-  u32 component_len[MAX_PATH_COMPONENTS];
+  struct components *components;
 };
 
 static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
   struct get_path_ctx *c = callback_ctx;
+  // NOTE: we need to store fields in temporary variables because a call like
+  // the the following results in a relocation error in kernel 5.5 x86:
+  // BPF_CORE_READ(c->current.dentry, d_parent);
+  // > applying relocation `FieldByteOffset` missing target BTF info for type
+  //   `909` at instruction #472
+  // This happens only in `sched_process_exec`, which uses raw tracepoints,
+  // while it doesn't happen in file-system-monitor, which uses lsm/kprobe
+  // programs.
+  struct dentry *current_dentry = c->current.dentry;
+  struct vfsmount *current_mnt = c->current.mnt;
   struct dentry *parent_dentry = BPF_CORE_READ(c->current.dentry, d_parent);
 
   // Get root dentry of the file-system mount point.
-  struct dentry *root_dentry = BPF_CORE_READ(c->current.mnt, mnt_root);
+  struct dentry *root_dentry = BPF_CORE_READ(current_mnt, mnt_root);
 
   // If a dentry is the parent of itself, we should have reached to root.
   // The topmost dentry must match root_dentry.
-  if (c->current.dentry == parent_dentry && c->current.dentry != root_dentry) {
+  if (current_dentry == parent_dentry && current_dentry != root_dentry) {
     LOG_ERROR("We reached root, but not mount root");
     return LOOP_STOP;
   }
 
   // If we've successfully reached the top of our file-system
-  if (c->current.dentry == root_dentry) {
+  if (current_dentry == root_dentry) {
     struct mount *current_mount =
         container_of(c->current.mnt, struct mount, mnt);
     struct mount *parent_mount = BPF_CORE_READ(current_mount, mnt_parent);
@@ -89,10 +117,12 @@ static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
   }
 
   // Add this dentry name to path
-  struct qstr entry = BPF_CORE_READ(c->current.dentry, d_name);
-  if (i < MAX_PATH_COMPONENTS) {
-    c->component_len[i] = entry.len;
-    c->component_name[i] = entry.name;
+  struct qstr entry = BPF_CORE_READ(current_dentry, d_name);
+  u32 next = c->components->total_components;
+  if (next < MAX_PATH_COMPONENTS) {
+    c->components->component_len[next] = entry.len;
+    c->components->component_name[next] = entry.name;
+    c->components->total_components++;
   }
   c->current.dentry = parent_dentry;
   return LOOP_CONTINUE;
@@ -103,13 +133,11 @@ static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
 // because the first component will always be the initial dentry.
 static __always_inline long append_path_component(u32 i, void *callback_ctx) {
   struct get_path_ctx *c = callback_ctx;
-  int t = MAX_PATH_COMPONENTS - i - 1;
+  int t = c->components->total_components - i - 1;
   if (t < 0 || t >= MAX_PATH_COMPONENTS)
     return LOOP_STOP;
-  char *name = (char *)c->component_name[t];
-  int len = c->component_len[t];
-  if (len == 0)
-    return LOOP_CONTINUE;
+  char *name = (char *)c->components->component_name[t];
+  int len = c->components->component_len[t];
   buffer_append_str(c->buffer, c->index, "/", 1);
   buffer_append_str(c->buffer, c->index, name, len);
   return LOOP_CONTINUE;
@@ -118,16 +146,21 @@ static __always_inline long append_path_component(u32 i, void *callback_ctx) {
 // Copy to buffer/index the path of the file pointed by dentry/path.
 static void get_path_str(struct path *path, struct buffer *buffer,
                          struct buffer_index *index) {
+
+  u32 key = 0;
   struct get_path_ctx c;
+  struct components *components = bpf_map_lookup_elem(&components_map, &key);
+  if (!components) {
+    LOG_ERROR("can't get context memory");
+    return;
+  }
+  c.components = components;
+  components->total_components = 0;
   c.index = index;
   c.buffer = buffer;
-  __builtin_memset(c.component_name, 0, sizeof(c.component_name));
-  __builtin_memset(c.component_len, 0, sizeof(c.component_len));
   c.current.dentry = path->dentry;
   c.current.mnt = path->mnt;
   buffer_index_init(buffer, index);
-  LOOP(MAX_PATH_COMPONENTS, get_dentry_name, &c);
-  LOOP(MAX_PATH_COMPONENTS, append_path_component, &c);
-  return;
-  // TODO: use bpf_d_path when available
+  LOOP(MAX_PATH_COMPONENTS, MAX_PATH_UNROLL, get_dentry_name, &c);
+  LOOP(MAX_PATH_COMPONENTS, MAX_PATH_UNROLL, append_path_component, &c);
 }

--- a/crates/bpf-builder/include/get_path.bpf.h
+++ b/crates/bpf-builder/include/get_path.bpf.h
@@ -1,6 +1,45 @@
 #pragma once
+#include "common.bpf.h"
 #include "loop.bpf.h"
 #include "output.bpf.h"
+#include "vmlinux.h"
+
+// Note on kernel data structures:
+//
+// - struct super_block:
+//     is implemented by each filesystem and is used to store information about
+//     that specific filesystem.
+//
+// - struct vfsmount:
+//     contains information about the mount point, such as its location and
+//     mount flags. It's contained inside struct mount.
+//
+// - struct inode:
+//     metadata about a file or directory, such as owner, permissions, size,
+//     etc. Unix file-systems usually store inodes on a special section on disk,
+//     while some other file-systems attach this to the file blob itself.
+//
+// - struct dentry:
+//     a directory entry is a specific component in a path. Among other things,
+//     it contains the path component name, a pointer to the parent dentry and a
+//     pointer to associated inode. These are not physically persisted on disk
+//     and VFS constructs dentry objects on the fly, as needed, when performing
+//     directory operations.
+//
+// - struct file:
+//     represent a file opened by a process. It's created in response to the
+//     open system call. There can be multiple struct file objects for the same
+//     file. The pointed at dentry/inode instead are unique.
+//
+// - struct path:
+//     it's a simple container. A dentry by itself has no pointer to its mount
+//     point, making it insufficient for determining a full path. This is why
+//     the functions in this file operate on struct path instead.
+//     struct path {
+//     	struct vfsmount *mnt;
+//     	struct dentry *dentry;
+//     };
+//
 
 #define MAX_PATH_COMPONENTS 20
 
@@ -9,11 +48,8 @@ struct get_path_ctx {
   struct buffer *buffer;
   struct buffer_index *index;
 
-  // Current dentry being iterated
-  struct dentry *dentry;
-  struct vfsmount *vfsmnt;
-  struct mount *mnt_p;
-  struct mount *mnt_parent_p;
+  // Current dentry and vfsmount being iterated by get_dentry_name.
+  struct path current;
 
   // Internal list of path components, from dentry to the root
   const unsigned char *component_name[MAX_PATH_COMPONENTS];
@@ -22,35 +58,44 @@ struct get_path_ctx {
 
 static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
   struct get_path_ctx *c = callback_ctx;
-  if (!c)
-    return 1;
-  struct dentry *mnt_root = (struct dentry *)BPF_CORE_READ(c->vfsmnt, mnt_root);
-  struct dentry *d_parent = BPF_CORE_READ(c->dentry, d_parent);
-  // If a dentry is the parent of itself, or if it matches the root
-  if (c->dentry == mnt_root || c->dentry == d_parent) {
-    if (c->dentry != mnt_root) {
-      // We reached root, but not mount root - escaped?
-      return 1;
-    }
-    if (c->mnt_p != c->mnt_parent_p) {
-      // We reached root, but not global root - continue with mount point
-      c->dentry = BPF_CORE_READ(c->mnt_p, mnt_mountpoint);
-      c->mnt_p = BPF_CORE_READ(c->mnt_p, mnt_parent);
-      c->mnt_parent_p = BPF_CORE_READ(c->mnt_p, mnt_parent);
-      c->vfsmnt = &c->mnt_p->mnt;
-      return 0;
-    }
-    // Global root - path fully parsed
-    return 1;
+  struct dentry *parent_dentry = BPF_CORE_READ(c->current.dentry, d_parent);
+
+  // Get root dentry of the file-system mount point.
+  struct dentry *root_dentry = BPF_CORE_READ(c->current.mnt, mnt_root);
+
+  // If a dentry is the parent of itself, we should have reached to root.
+  // The topmost dentry must match root_dentry.
+  if (c->current.dentry == parent_dentry && c->current.dentry != root_dentry) {
+    LOG_ERROR("We reached root, but not mount root");
+    return LOOP_STOP;
   }
+
+  // If we've successfully reached the top of our file-system
+  if (c->current.dentry == root_dentry) {
+    struct mount *current_mount =
+        container_of(c->current.mnt, struct mount, mnt);
+    struct mount *parent_mount = BPF_CORE_READ(current_mount, mnt_parent);
+    if (current_mount == parent_mount) {
+      // Global root - path fully parsed
+      return LOOP_STOP;
+    } else {
+      // We reached root, but not global root - continue with mount point.
+      // mnt_mountpoint contains the dentry where this mount point is mounted
+      // at.
+      c->current.mnt = &parent_mount->mnt;
+      c->current.dentry = BPF_CORE_READ(current_mount, mnt_mountpoint);
+      return LOOP_CONTINUE;
+    }
+  }
+
   // Add this dentry name to path
-  struct qstr entry = BPF_CORE_READ(c->dentry, d_name);
+  struct qstr entry = BPF_CORE_READ(c->current.dentry, d_name);
   if (i < MAX_PATH_COMPONENTS) {
     c->component_len[i] = entry.len;
     c->component_name[i] = entry.name;
   }
-  c->dentry = d_parent;
-  return 0;
+  c->current.dentry = parent_dentry;
+  return LOOP_CONTINUE;
 }
 
 // Build the full path by joining the output components of get_dentry_name.
@@ -60,30 +105,29 @@ static __always_inline long append_path_component(u32 i, void *callback_ctx) {
   struct get_path_ctx *c = callback_ctx;
   int t = MAX_PATH_COMPONENTS - i - 1;
   if (t < 0 || t >= MAX_PATH_COMPONENTS)
-    return 1;
+    return LOOP_STOP;
   char *name = (char *)c->component_name[t];
   int len = c->component_len[t];
   if (len == 0)
-    return 0;
+    return LOOP_CONTINUE;
   buffer_append_str(c->buffer, c->index, "/", 1);
   buffer_append_str(c->buffer, c->index, name, len);
-  return 0;
+  return LOOP_CONTINUE;
 }
 
 // Copy to buffer/index the path of the file pointed by dentry/path.
-static void get_path_str(struct dentry *dentry, struct path *path,
-                         struct buffer *buffer, struct buffer_index *index) {
+static void get_path_str(struct path *path, struct buffer *buffer,
+                         struct buffer_index *index) {
   struct get_path_ctx c;
   c.index = index;
   c.buffer = buffer;
   __builtin_memset(c.component_name, 0, sizeof(c.component_name));
   __builtin_memset(c.component_len, 0, sizeof(c.component_len));
-  c.dentry = dentry;
-  c.vfsmnt = BPF_CORE_READ(path, mnt);
-  c.mnt_p = container_of(c.vfsmnt, struct mount, mnt);
-  c.mnt_parent_p = BPF_CORE_READ(c.mnt_p, mnt_parent);
+  c.current.dentry = path->dentry;
+  c.current.mnt = path->mnt;
   buffer_index_init(buffer, index);
   LOOP(MAX_PATH_COMPONENTS, get_dentry_name, &c);
   LOOP(MAX_PATH_COMPONENTS, append_path_component, &c);
   return;
+  // TODO: use bpf_d_path when available
 }

--- a/crates/bpf-builder/include/get_path.bpf.h
+++ b/crates/bpf-builder/include/get_path.bpf.h
@@ -1,0 +1,89 @@
+#pragma once
+#include "loop.bpf.h"
+#include "output.bpf.h"
+
+#define MAX_PATH_COMPONENTS 20
+
+struct get_path_ctx {
+  // Output of get_path_str
+  struct buffer *buffer;
+  struct buffer_index *index;
+
+  // Current dentry being iterated
+  struct dentry *dentry;
+  struct vfsmount *vfsmnt;
+  struct mount *mnt_p;
+  struct mount *mnt_parent_p;
+
+  // Internal list of path components, from dentry to the root
+  const unsigned char *component_name[MAX_PATH_COMPONENTS];
+  u32 component_len[MAX_PATH_COMPONENTS];
+};
+
+static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
+  struct get_path_ctx *c = callback_ctx;
+  if (!c)
+    return 1;
+  struct dentry *mnt_root = (struct dentry *)BPF_CORE_READ(c->vfsmnt, mnt_root);
+  struct dentry *d_parent = BPF_CORE_READ(c->dentry, d_parent);
+  // If a dentry is the parent of itself, or if it matches the root
+  if (c->dentry == mnt_root || c->dentry == d_parent) {
+    if (c->dentry != mnt_root) {
+      // We reached root, but not mount root - escaped?
+      return 1;
+    }
+    if (c->mnt_p != c->mnt_parent_p) {
+      // We reached root, but not global root - continue with mount point
+      c->dentry = BPF_CORE_READ(c->mnt_p, mnt_mountpoint);
+      c->mnt_p = BPF_CORE_READ(c->mnt_p, mnt_parent);
+      c->mnt_parent_p = BPF_CORE_READ(c->mnt_p, mnt_parent);
+      c->vfsmnt = &c->mnt_p->mnt;
+      return 0;
+    }
+    // Global root - path fully parsed
+    return 1;
+  }
+  // Add this dentry name to path
+  struct qstr entry = BPF_CORE_READ(c->dentry, d_name);
+  if (i < MAX_PATH_COMPONENTS) {
+    c->component_len[i] = entry.len;
+    c->component_name[i] = entry.name;
+  }
+  c->dentry = d_parent;
+  return 0;
+}
+
+// Build the full path by joining the output components of get_dentry_name.
+// The loop starts from the end (t goes from (MAX_PATH_COMPONENTS-1) to 0)
+// because the first component will always be the initial dentry.
+static __always_inline long append_path_component(u32 i, void *callback_ctx) {
+  struct get_path_ctx *c = callback_ctx;
+  int t = MAX_PATH_COMPONENTS - i - 1;
+  if (t < 0 || t >= MAX_PATH_COMPONENTS)
+    return 1;
+  char *name = (char *)c->component_name[t];
+  int len = c->component_len[t];
+  if (len == 0)
+    return 0;
+  buffer_append_str(c->buffer, c->index, "/", 1);
+  buffer_append_str(c->buffer, c->index, name, len);
+  return 0;
+}
+
+// Copy to buffer/index the path of the file pointed by dentry/path.
+static void get_path_str(struct dentry *dentry, struct path *path,
+                         struct buffer *buffer, struct buffer_index *index) {
+  struct get_path_ctx c;
+  c.index = index;
+  c.buffer = buffer;
+  __builtin_memset(c.component_name, 0, sizeof(c.component_name));
+  __builtin_memset(c.component_len, 0, sizeof(c.component_len));
+  c.dentry = dentry;
+  c.vfsmnt = BPF_CORE_READ(path, mnt);
+  c.mnt_p = container_of(c.vfsmnt, struct mount, mnt);
+  c.mnt_parent_p = BPF_CORE_READ(c.mnt_p, mnt_parent);
+  buffer_index_init(buffer, index);
+  LOOP(MAX_PATH_COMPONENTS, get_dentry_name, &c);
+  LOOP(MAX_PATH_COMPONENTS, append_path_component, &c);
+  return;
+}

--- a/crates/bpf-builder/include/loop.bpf.h
+++ b/crates/bpf-builder/include/loop.bpf.h
@@ -18,7 +18,7 @@
 // error, even if inside a dead-code elimination branch.
 #define LOOP(max_iterations, callback_fn, ctx)                                 \
   _Pragma("unroll") for (int i = 0; i < max_iterations; i++) {                 \
-    if (callback_fn(i, ctx) == 1)                                              \
+    if (callback_fn(i, ctx) == LOOP_STOP)                                      \
       break;                                                                   \
   }
 #else
@@ -27,8 +27,11 @@
     bpf_loop(max_iterations, callback_fn, ctx, 0);                             \
   } else {                                                                     \
     _Pragma("unroll") for (int i = 0; i < max_iterations; i++) {               \
-      if (callback_fn(i, ctx) == 1)                                            \
+      if (callback_fn(i, ctx) == LOOP_STOP)                                    \
         break;                                                                 \
     }                                                                          \
   }
 #endif
+
+#define LOOP_CONTINUE 0
+#define LOOP_STOP 1

--- a/crates/bpf-builder/include/loop.bpf.h
+++ b/crates/bpf-builder/include/loop.bpf.h
@@ -17,7 +17,7 @@
 // On kernel <= 5.13 taking the address of a function results in a verifier
 // error, even if inside a dead-code elimination branch.
 #define LOOP(max_iterations, max_unroll, callback_fn, ctx)                     \
-  _Pragma("unroll") for (int i = 0; i < 10; i++) {                             \
+  _Pragma("unroll") for (int i = 0; i < max_unroll; i++) {                     \
     if (callback_fn(i, ctx) == LOOP_STOP)                                      \
       break;                                                                   \
   }

--- a/crates/bpf-builder/include/loop.bpf.h
+++ b/crates/bpf-builder/include/loop.bpf.h
@@ -16,17 +16,17 @@
 #ifdef FEATURE_NO_FN_POINTERS
 // On kernel <= 5.13 taking the address of a function results in a verifier
 // error, even if inside a dead-code elimination branch.
-#define LOOP(max_iterations, callback_fn, ctx)                                 \
-  _Pragma("unroll") for (int i = 0; i < max_iterations; i++) {                 \
+#define LOOP(max_iterations, max_unroll, callback_fn, ctx)                     \
+  _Pragma("unroll") for (int i = 0; i < 10; i++) {                             \
     if (callback_fn(i, ctx) == LOOP_STOP)                                      \
       break;                                                                   \
   }
 #else
-#define LOOP(max_iterations, callback_fn, ctx)                                 \
+#define LOOP(max_iterations, max_unroll, callback_fn, ctx)                     \
   if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 17, 0)) {                      \
     bpf_loop(max_iterations, callback_fn, ctx, 0);                             \
   } else {                                                                     \
-    _Pragma("unroll") for (int i = 0; i < max_iterations; i++) {               \
+    _Pragma("unroll") for (int i = 0; i < max_unroll; i++) {                   \
       if (callback_fn(i, ctx) == LOOP_STOP)                                    \
         break;                                                                 \
     }                                                                          \

--- a/crates/bpf-builder/src/lib.rs
+++ b/crates/bpf-builder/src/lib.rs
@@ -21,6 +21,7 @@ pub fn build(name: &str, source: &str) -> Result<(), Box<dyn std::error::Error>>
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/buffer.bpf.h");
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/output.bpf.h");
     println!("cargo:rerun-if-changed={INCLUDE_PATH}/loop.bpf.h");
+    println!("cargo:rerun-if-changed={INCLUDE_PATH}/get_path.bpf.h");
 
     let out_file = PathBuf::from(env::var("OUT_DIR")?).join(name);
 

--- a/crates/modules/file-system-monitor/probes.bpf.c
+++ b/crates/modules/file-system-monitor/probes.bpf.c
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "buffer.bpf.h"
 #include "common.bpf.h"
-#include "loop.bpf.h"
-#include "output.bpf.h"
+#include "get_path.bpf.h"
 char LICENSE[] SEC("license") = "GPL";
 
 #define FILE_CREATED 0
@@ -12,7 +11,6 @@ char LICENSE[] SEC("license") = "GPL";
 #define FILE_OPENED 4
 #define FILE_LINK 5
 #define FILE_RENAME 6
-#define MAX_PATH_COMPONENTS 20
 
 struct file_opened_event {
   struct buffer_index filename;
@@ -39,90 +37,6 @@ OUTPUT_MAP(events, fs_event, {
   struct file_link_event link;
   struct file_rename_event rename;
 });
-
-struct get_path_ctx {
-  // Output of get_path_str
-  struct buffer *buffer;
-  struct buffer_index *index;
-
-  // Current dentry being iterated
-  struct dentry *dentry;
-  struct vfsmount *vfsmnt;
-  struct mount *mnt_p;
-  struct mount *mnt_parent_p;
-
-  // Internal list of path components, from dentry to the root
-  const unsigned char *component_name[MAX_PATH_COMPONENTS];
-  u32 component_len[MAX_PATH_COMPONENTS];
-};
-
-static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
-  struct get_path_ctx *c = callback_ctx;
-  if (!c)
-    return 1;
-  struct dentry *mnt_root = (struct dentry *)BPF_CORE_READ(c->vfsmnt, mnt_root);
-  struct dentry *d_parent = BPF_CORE_READ(c->dentry, d_parent);
-  // If a dentry is the parent of itself, or if it matches the root
-  if (c->dentry == mnt_root || c->dentry == d_parent) {
-    if (c->dentry != mnt_root) {
-      // We reached root, but not mount root - escaped?
-      return 1;
-    }
-    if (c->mnt_p != c->mnt_parent_p) {
-      // We reached root, but not global root - continue with mount point
-      c->dentry = BPF_CORE_READ(c->mnt_p, mnt_mountpoint);
-      c->mnt_p = BPF_CORE_READ(c->mnt_p, mnt_parent);
-      c->mnt_parent_p = BPF_CORE_READ(c->mnt_p, mnt_parent);
-      c->vfsmnt = &c->mnt_p->mnt;
-      return 0;
-    }
-    // Global root - path fully parsed
-    return 1;
-  }
-  // Add this dentry name to path
-  struct qstr entry = BPF_CORE_READ(c->dentry, d_name);
-  if (i < MAX_PATH_COMPONENTS) {
-    c->component_len[i] = entry.len;
-    c->component_name[i] = entry.name;
-  }
-  c->dentry = d_parent;
-  return 0;
-}
-
-// Build the full path by joining the output components of get_dentry_name.
-// The loop starts from the end (t goes from (MAX_PATH_COMPONENTS-1) to 0)
-// because the first component will always be the initial dentry.
-static __always_inline long append_path_component(u32 i, void *callback_ctx) {
-  struct get_path_ctx *c = callback_ctx;
-  int t = MAX_PATH_COMPONENTS - i - 1;
-  if (t < 0 || t >= MAX_PATH_COMPONENTS)
-    return 1;
-  char *name = (char *)c->component_name[t];
-  int len = c->component_len[t];
-  if (len == 0)
-    return 0;
-  buffer_append_str(c->buffer, c->index, "/", 1);
-  buffer_append_str(c->buffer, c->index, name, len);
-  return 0;
-}
-
-// Copy to buffer/index the path of the file pointed by dentry/path.
-static void get_path_str(struct dentry *dentry, struct path *path,
-                         struct buffer *buffer, struct buffer_index *index) {
-  struct get_path_ctx c;
-  c.index = index;
-  c.buffer = buffer;
-  __builtin_memset(c.component_name, 0, sizeof(c.component_name));
-  __builtin_memset(c.component_len, 0, sizeof(c.component_len));
-  c.dentry = dentry;
-  c.vfsmnt = BPF_CORE_READ(path, mnt);
-  c.mnt_p = container_of(c.vfsmnt, struct mount, mnt);
-  c.mnt_parent_p = BPF_CORE_READ(c.mnt_p, mnt_parent);
-  buffer_index_init(buffer, index);
-  LOOP(MAX_PATH_COMPONENTS, get_dentry_name, &c);
-  LOOP(MAX_PATH_COMPONENTS, append_path_component, &c);
-  return;
-}
 
 PULSAR_LSM_HOOK(path_mknod, struct path *, dir, struct dentry *, dentry,
                 umode_t, mode, unsigned int, dev);

--- a/crates/modules/file-system-monitor/probes.bpf.c
+++ b/crates/modules/file-system-monitor/probes.bpf.c
@@ -97,10 +97,10 @@ static __always_inline void on_path_link(void *ctx, struct dentry *old_dentry,
   struct fs_event *event = fs_event_init(FILE_LINK);
   if (!event)
     return;
-  struct path new_path = make_path(new_dentry, new_dir);
-  get_path_str(&new_path, &event->buffer, &event->link.source);
-  struct path old_path = make_path(old_dentry, new_dir);
-  get_path_str(&old_path, &event->buffer, &event->link.destination);
+  struct path source = make_path(new_dentry, new_dir);
+  get_path_str(&source, &event->buffer, &event->link.source);
+  struct path destination = make_path(old_dentry, new_dir);
+  get_path_str(&destination, &event->buffer, &event->link.destination);
   event->link.hard_link = true;
   output_event(ctx, &events, event, sizeof(struct fs_event), event->buffer.len);
 }
@@ -155,9 +155,9 @@ static __always_inline void on_path_rename(void *ctx, struct path *old_dir,
   struct fs_event *event = fs_event_init(FILE_RENAME);
   if (!event)
     return;
-  struct path old_path = make_path(old_dentry, old_dir);
-  struct path new_path = make_path(new_dentry, new_dir);
-  get_path_str(&old_path, &event->buffer, &event->rename.source);
-  get_path_str(&new_path, &event->buffer, &event->rename.destination);
+  struct path source = make_path(old_dentry, old_dir);
+  struct path destination = make_path(new_dentry, new_dir);
+  get_path_str(&source, &event->buffer, &event->rename.source);
+  get_path_str(&destination, &event->buffer, &event->rename.destination);
   output_event(ctx, &events, event, sizeof(struct fs_event), event->buffer.len);
 }

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -131,7 +131,7 @@ int BPF_PROG(sched_process_exec, struct task_struct *p, pid_t old_pid,
                       BUFFER_MAX);
   } else {
     struct path path = BPF_CORE_READ(bprm, file, f_path);
-    get_path_str(path.dentry, &path, &event->buffer, &event->exec.filename);
+    get_path_str(&path, &event->buffer, &event->exec.filename);
   }
 
   char *image = (char *)&event->buffer.buffer;

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -117,6 +117,10 @@ int BPF_PROG(sched_process_exec, struct task_struct *p, pid_t old_pid,
   event->timestamp = bpf_ktime_get_ns();
   event->pid = tgid;
   event->exec.argc = BPF_CORE_READ(bprm, argc);
+  // This is needed because the first MAX_IMAGE_LEN bytes of buffer will
+  // be used as a lookup key for the target and whitelist maps and garbage
+  // would make the search fail.
+  __builtin_memset((char *)&event->buffer.buffer, 0, MAX_IMAGE_LEN);
 
   // We want to get the absolute path of the executable we're running.
   // When executing a process with a relative path, bprm->filename won't be

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -210,6 +210,7 @@ pub mod test_suite {
             tests: vec![
                 fork_event(),
                 exec_event(),
+                relative_exec_event(),
                 exit_event(),
                 exit_event_no_thread(),
                 inherit_policy(),
@@ -264,6 +265,30 @@ pub mod test_suite {
                         (argc, 2, "number of arguments"),
                         (argv, String::from("echo\0-n\0"), "arguments")
                     ),
+                )
+                .report()
+        })
+    }
+
+    fn relative_exec_event() -> TestCase {
+        TestCase::new("relative_exec_event", async {
+            let mut child_pid = Pid::from_raw(0);
+            let echo_buff = which("echo").unwrap();
+            let echo_path = echo_buff.as_path().to_str().unwrap().to_string();
+            test_runner()
+                .run(|| {
+                    let mut child = std::process::Command::new("./echo")
+                        .current_dir(echo_buff.as_path().parent().unwrap())
+                        .arg("-n")
+                        .spawn()
+                        .unwrap();
+                    child_pid = Pid::from_raw(child.id() as i32);
+                    child.wait().unwrap();
+                })
+                .await
+                .expect_event_from_pid(
+                    child_pid,
+                    event_check!(ProcessEvent::Exec, (filename, echo_path, "exec filename")),
                 )
                 .report()
         })

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -273,7 +273,7 @@ pub mod test_suite {
     fn relative_exec_event() -> TestCase {
         TestCase::new("relative_exec_event", async {
             let mut child_pid = Pid::from_raw(0);
-            let echo_buff = which("echo").unwrap();
+            let echo_buff = which("echo").unwrap().canonicalize().unwrap();
             let echo_path = echo_buff.as_path().to_str().unwrap().to_string();
             test_runner()
                 .run(|| {

--- a/scripts/check_bytecode.sh
+++ b/scripts/check_bytecode.sh
@@ -9,6 +9,6 @@ set -x
 set -e
 
 # Compile eBPF to /tmp/obj.o
-clang -g -O2 -c $1 -o /tmp/obj.o -target bpf -D__TARGET_ARCH_x86 -I crates/bpf-common/include/ -I crates/bpf-common/include/x86_64/
+clang -g -O2 -c $1 -o /tmp/obj.o -target bpf -D__TARGET_ARCH_x86 -I crates/bpf-builder/include/ -I crates/bpf-builder/include/x86_64/
 sleep 1
 llvm-objdump -S --no-show-raw-insn /tmp/obj.o


### PR DESCRIPTION
Fix process-monitor to always get the absolute file path on exec.
Before this change executing a file with a relative path would have resulted in an exec event with path `./executable`. After this change it will be `/path/to/executable`.

Since the code to extract the full file path is quite complex, we'll execute it only when needed.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
