### PR TITLE
Emit cgroup events from process-monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.26.2",
  "procfs",
  "sys-mount",
  "thiserror",
@@ -234,6 +234,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cgroups-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b098e7c3a70d03c288fa0a96ccf13e770eb3d78c4cc0e1549b3c13215d5f965"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "regex",
+ "thiserror",
+]
 
 [[package]]
 name = "chrono"
@@ -496,7 +509,7 @@ dependencies = [
  "bpf-builder",
  "bpf-common",
  "log",
- "nix",
+ "nix 0.26.2",
  "pulsar-core",
  "tokio",
 ]
@@ -975,7 +988,7 @@ dependencies = [
  "bpf-common",
  "dns-parser",
  "log",
- "nix",
+ "nix 0.26.2",
  "pulsar-core",
  "tokio",
 ]
@@ -985,6 +998,18 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -1198,9 +1223,11 @@ dependencies = [
  "anyhow",
  "bpf-builder",
  "bpf-common",
+ "cgroups-rs",
  "log",
- "nix",
+ "nix 0.26.2",
  "pulsar-core",
+ "rand",
  "thiserror",
  "tokio",
  "which",
@@ -1236,7 +1263,7 @@ dependencies = [
  "log",
  "logger",
  "network-monitor",
- "nix",
+ "nix 0.26.2",
  "process-monitor",
  "pulsar-core",
  "rules-engine",
@@ -1253,7 +1280,7 @@ dependencies = [
  "anyhow",
  "bpf-common",
  "log",
- "nix",
+ "nix 0.26.2",
  "semver",
  "serde",
  "thiserror",
@@ -1661,7 +1688,7 @@ dependencies = [
  "libtest-mimic",
  "log",
  "network-monitor",
- "nix",
+ "nix 0.26.2",
  "process-monitor",
  "tokio",
 ]

--- a/crates/bpf-builder/include/output.bpf.h
+++ b/crates/bpf-builder/include/output.bpf.h
@@ -8,8 +8,10 @@
   struct struct_name {                                                         \
     u64 timestamp;                                                             \
     pid_t pid;                                                                 \
-    u32 event_type;                                                            \
-    union variants;                                                            \
+    struct {                                                                   \
+      u32 event_type;                                                          \
+      union variants;                                                          \
+    };                                                                         \
     struct buffer buffer;                                                      \
   };                                                                           \
                                                                                \

--- a/crates/bpf-common/src/program.rs
+++ b/crates/bpf-common/src/program.rs
@@ -435,6 +435,14 @@ impl Program {
                                 );
                             }
                             for buffer in buffers.iter_mut().take(events.read) {
+                                if buffer.len() < event_size {
+                                    log::error!("sizeof T: {}", size_of::<T>());
+                                    log::error!(
+                                        "sizeof RawBpfEvent<T>: {}",
+                                        size_of::<RawBpfEvent<T>>()
+                                    );
+                                    panic!("Buffer too short. buffer.len() = {}", buffer.len(),);
+                                }
                                 let mut buffer =
                                     std::mem::replace(buffer, BytesMut::with_capacity(buffer_size));
                                 let ptr = buffer.as_ptr() as *const RawBpfEvent<T>;

--- a/crates/modules/process-monitor/Cargo.toml
+++ b/crates/modules/process-monitor/Cargo.toml
@@ -6,7 +6,12 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
-test-suite = ["bpf-common/test-utils", "which"]
+test-suite = [
+  "bpf-common/test-utils",
+  "which",
+  "cgroups-rs",
+  "rand"
+]
 
 [dependencies]
 bpf-common = { path = "../../bpf-common" }
@@ -16,8 +21,12 @@ tokio = { version = "1", features = ["full"] }
 nix = "0.26.2"
 log = "0.4"
 thiserror = "1"
-which = { version = "4.2.5", optional = true }
 anyhow = "1.0.65"
+
+# Test deps
+which = { version = "4.2.5", optional = true }
+cgroups-rs = { version = "0.3.2", optional = true }
+rand = { version = "0.8.5", optional = true }
 
 [build-dependencies]
 bpf-builder = { path = "../../bpf-builder" }

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -213,6 +213,19 @@ pub enum Payload {
     ChangeParent {
         ppid: i32,
     },
+    CgroupCreated {
+        cgroup_path: String,
+        cgroup_id: u64,
+    },
+    CgroupDeleted {
+        cgroup_path: String,
+        cgroup_id: u64,
+    },
+    CgroupAttach {
+        cgroup_path: String,
+        cgroup_id: u64,
+        attached_pid: i32,
+    },
     SyscallActivity {
         #[validatron(skip)]
         histogram: Vec<u64>,
@@ -280,6 +293,9 @@ impl fmt::Display for Payload {
             Payload::Exec { filename, argc, argv } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv} }}"),
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
             Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
+            Payload::CgroupCreated { cgroup_path, cgroup_id } => write!(f,"Cgroup created {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),
+            Payload::CgroupDeleted { cgroup_path, cgroup_id } => write!(f,"Cgroup deleted {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),
+            Payload::CgroupAttach { cgroup_path, cgroup_id, attached_pid } => write!(f,"Process attached to cgroup {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id}, attached_pid {attached_pid} }}"),
             Payload::SyscallActivity { .. } => write!(f,"Syscall Activity"),
             Payload::Bind { address, is_tcp } => write!(f,"Bind {{ address: {address}, is_tcp: {is_tcp} }}"),
             Payload::Listen { address } => write!(f,"Listen {{ address: {address} }}"),  


### PR DESCRIPTION
Added cgroup integration inside process-monitor.
I've decided to split work on #13 in two PRs, this is the simplest one, while in the next one I'll work on filtering.

|tracepoint|event generated|
|-------------------|------------------------------------|
|`cgroup_mkdir`| `Payload::CgroupCreated`|
|`cgroup_rmdir`|`Payload::CgroupDeleted`|
|`cgroup_attach_task`|`Payload::CgroupAttach`|


I've successfully tested it on x86_64 (5.5 and 5.19) and aarch64 (6.0)

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
