### PR TITLE
misc(process-monitor): use bpf_loop in orphans collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,7 +118,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "base64 0.20.0",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -154,10 +165,10 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.11.0"
-source = "git+https://github.com/aya-rs/aya?rev=22d79312f7f5d8afd97dfaa42d3cd063206772e3#22d79312f7f5d8afd97dfaa42d3cd063206772e3"
+source = "git+https://github.com/aya-rs/aya?rev=41fe944a1a60279705f5ed156b25675ea302e861#41fe944a1a60279705f5ed156b25675ea302e861"
 dependencies = [
  "aya-obj",
- "bitflags",
+ "bitflags 2.2.1",
  "bytes",
  "lazy_static",
  "libc",
@@ -171,9 +182,11 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?rev=22d79312f7f5d8afd97dfaa42d3cd063206772e3#22d79312f7f5d8afd97dfaa42d3cd063206772e3"
+source = "git+https://github.com/aya-rs/aya?rev=41fe944a1a60279705f5ed156b25675ea302e861#41fe944a1a60279705f5ed156b25675ea302e861"
 dependencies = [
  "bytes",
+ "core-error",
+ "hashbrown 0.13.2",
  "log",
  "object",
  "thiserror",
@@ -211,6 +224,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
 
 [[package]]
 name = "block-buffer"
@@ -334,7 +353,7 @@ checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -386,6 +405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +428,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -736,7 +764,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
 ]
 
 [[package]]
@@ -744,6 +772,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
+]
 
 [[package]]
 name = "heck"
@@ -1081,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
 ]
@@ -1092,7 +1129,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
@@ -1131,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
+checksum = "d08090140cfee2e09897d6be320b47a45b79eb68b414de87130f9532966e2f1d"
 dependencies = [
  "memchr",
 ]
@@ -1276,7 +1313,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "hex",
  "lazy_static",
@@ -1377,7 +1414,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1441,7 +1478,7 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes",
  "libc",
@@ -1455,7 +1492,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.3.1",
  "io-lifetimes",
  "libc",
@@ -1716,7 +1753,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1af10c09a6d1f65753e52772a4621e00da8b1d772d0f24595b60ccd36d6b51"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "smart-default",
  "thiserror",
@@ -1909,7 +1946,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",

--- a/crates/bpf-builder/include/get_path.bpf.h
+++ b/crates/bpf-builder/include/get_path.bpf.h
@@ -86,7 +86,7 @@ static __always_inline long get_dentry_name(u32 i, void *callback_ctx) {
   // programs.
   struct dentry *current_dentry = c->current.dentry;
   struct vfsmount *current_mnt = c->current.mnt;
-  struct dentry *parent_dentry = BPF_CORE_READ(c->current.dentry, d_parent);
+  struct dentry *parent_dentry = BPF_CORE_READ(current_dentry, d_parent);
 
   // Get root dentry of the file-system mount point.
   struct dentry *root_dentry = BPF_CORE_READ(current_mnt, mnt_root);

--- a/crates/bpf-builder/include/output.bpf.h
+++ b/crates/bpf-builder/include/output.bpf.h
@@ -34,12 +34,12 @@
   }                                                                            \
                                                                                \
   /* Output map definition */                                                  \
-  struct bpf_map_def_aya SEC("maps/events") map_name = {                       \
-      .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,                                   \
-      .key_size = sizeof(int),                                                 \
-      .value_size = sizeof(u32),                                               \
-      .max_entries = 0,                                                        \
-  };
+  struct {                                                                     \
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);                               \
+    __type(key, int);                                                          \
+    __type(value, u32);                                                        \
+    __uint(max_entries, 0);                                                    \
+  } map_name SEC(".maps");
 
 // The BPF stack limit of 512 bytes is exceeded by network_event,
 // so we use a per-cpu array as a workaround

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -15,7 +15,7 @@ test-utils = [
 ]
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", rev = "22d79312f7f5d8afd97dfaa42d3cd063206772e3", features = ["async_tokio"] }
+aya = { git = "https://github.com/aya-rs/aya", rev = "41fe944a1a60279705f5ed156b25675ea302e861", features = ["async_tokio"] }
 bytes = "1.3.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -222,6 +222,10 @@ static __always_inline void collect_orphans(pid_t tgid, struct task_struct *p) {
 
   struct task_struct *task = container_of(c.next, struct task_struct, sibling);
   LOOP(MAX_ORPHANS, MAX_ORPHANS_UNROLL, loop_collect_orphan, &c);
+  // Log a warning if we couln't process all children
+  if (c.next != c.last) {
+    LOG_ERROR("Couldn't iterate all children. Too many of them");
+  }
 }
 
 // This is attached to tracepoint:sched:sched_process_exit

--- a/crates/pulsar-core/src/platform/linux-aarch64.rs
+++ b/crates/pulsar-core/src/platform/linux-aarch64.rs
@@ -12,5 +12,6 @@ pub mod file {
         pub const O_APPEND: i32 = 0x400;
         pub const O_NONBLOCK: i32 = 0x800;
         pub const O_DIRECTORY: i32 = 0x4000;
+        pub const O_LARGEFILE: i32 = 0x20000;
     }
 }

--- a/crates/pulsar-core/src/platform/linux-riscv64.rs
+++ b/crates/pulsar-core/src/platform/linux-riscv64.rs
@@ -11,6 +11,7 @@ pub mod file {
         pub const O_TRUNC: i32 = 0x1000;
         pub const O_APPEND: i32 = 0x2000;
         pub const O_NONBLOCK: i32 = 0x4000;
+        pub const O_LARGEFILE: i32 = 0x8000;
         pub const O_DIRECTORY: i32 = 0x200000;
     }
 }

--- a/crates/pulsar-core/src/platform/linux-x86_64.rs
+++ b/crates/pulsar-core/src/platform/linux-x86_64.rs
@@ -11,6 +11,7 @@ pub mod file {
         pub const O_TRUNC: i32 = 0x200;
         pub const O_APPEND: i32 = 0x400;
         pub const O_NONBLOCK: i32 = 0x800;
+        pub const O_LARGEFILE: i32 = 0x8000;
         pub const O_DIRECTORY: i32 = 0x10000;
     }
 }


### PR DESCRIPTION
Fix #148

This PR replaces manual loops with the LOOP macro inside process-monitor.

~~Blocked by https://github.com/aya-rs/aya/issues/601~~