### PR TITLE
add cron exception to 'Read sensitive file' rule

### DIFF
--- a/rules/basic-rules.yaml
+++ b/rules/basic-rules.yaml
@@ -1,7 +1,13 @@
+# Checks read of sensitive files with the exception of cron (cron for Debian like and cronie for RedHat like and SLES)
 - name: Read sensitive file
   type: FileOpened
-  condition: (payload.filename IN ["/etc/shadow", "/etc/sudoers", "/etc/pam.conf", "/etc/security/pwquality.conf"] OR payload.filename STARTS_WITH "/etc/sudoers.d/" OR payload.filename STARTS_WITH "/etc/pam.d/") AND (payload.flags CONTAINS "O_RDONLY" OR payload.flags CONTAINS "O_RDWR")
-
+  condition: (
+    payload.filename IN ["/etc/shadow", "/etc/sudoers", "/etc/pam.conf", "/etc/security/pwquality.conf"]
+      OR payload.filename STARTS_WITH "/etc/sudoers.d/"
+        OR payload.filename STARTS_WITH "/etc/pam.d/"
+    ) AND (payload.flags CONTAINS "O_RDONLY" OR payload.flags CONTAINS "O_RDWR")
+    AND
+      NOT header.image IN ["/usr/sbin/cron", "/usr/sbin/crond"]
 
 - name: Truncate log files
   type: FileOpened


### PR DESCRIPTION
This pr adds `cron` daemon exception to 'Read sensitive file' rule. There are different implementation of `cron`, we are covering:
- `vixie-cron` fork of Debian for Debian like distributions
- `cronie` for RedHat like distributions and SLES
