### PR TITLE
refactor(event): add description field

### DIFF
--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -47,10 +47,15 @@ async fn desktop_nitifier_task(
 
 /// Check if the given event is a threat which should be notified to the user
 async fn handle_event(config: &Config, event: Arc<Event>) {
-    if let Some(Threat { source, info }) = &event.header().threat {
+    if let Some(Threat {
+        source,
+        description,
+        extra: _,
+    }) = &event.header().threat
+    {
         let payload = event.payload();
         let title = format!("Pulsar module {source} identified a threat");
-        let body = format!("{info}\n Source event: {payload}");
+        let body = format!("{description}\n Source event: {payload}");
         notify_send(config, vec![title, body]).await;
     }
 }

--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -82,9 +82,14 @@ pub mod terminal {
         let pid = &header.pid;
         let payload = event.payload();
 
-        if let Some(Threat { source, info }) = &event.header().threat {
+        if let Some(Threat {
+            source,
+            description,
+            extra: _,
+        }) = &event.header().threat
+        {
             println!(
-                "[{time} \x1b[1;30;43mTHREAT\x1b[0m  {image} ({pid})] [{source} - {info}] {payload}"
+                "[{time} \x1b[1;30;43mTHREAT\x1b[0m  {image} ({pid})] [{source} - {description}] {payload}"
             )
         } else {
             let source = &header.source;

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -47,17 +47,19 @@ pub struct Header {
 /// When an [`Event`] contains this information it should be considered
 /// a "threat event".
 ///
-/// It contains the name of the module that has identified the threat and
-/// custom additional information respectively in `source` and `info` fields.
+/// It contains the name of the module that has identified the threat, a human
+/// readable description and custom additional information respectively in the
+/// `source`, `description` and `info` fields.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Threat {
     pub source: ModuleName,
-    pub info: Value,
+    pub description: String,
+    pub extra: Option<Value>,
 }
 
 impl Display for Threat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write! {f, "{{ source: {}, info: {} }}", self.source, self.info}
+        write! {f, "{{ source: {}, info: {} }}", self.source, self.description}
     }
 }
 
@@ -225,6 +227,8 @@ pub enum Payload {
     },
     Custom {
         #[validatron(skip)]
+        description: String,
+        #[validatron(skip)]
         value: Value,
     },
     #[validatron(skip)]
@@ -269,7 +273,7 @@ impl fmt::Display for Payload {
                 write!(f," }}")
             },
             Payload::Send { source, destination, len, is_tcp } => write!(f,"Send {{ source: {source}, destination {destination}, len: {len}, is_tcp: {is_tcp} }}"),
-            Payload::Custom { value } => write!(f,"Custom {{ value: {value} }}"),
+            Payload::Custom { description, value } => write!(f,"Custom {{ description: {description} value: {value} }}"),
             Payload::Empty => write!(f,"Empty"),
         }
     }

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -273,7 +273,7 @@ impl fmt::Display for Payload {
                 write!(f," }}")
             },
             Payload::Send { source, destination, len, is_tcp } => write!(f,"Send {{ source: {source}, destination {destination}, len: {len}, is_tcp: {is_tcp} }}"),
-            Payload::Custom { description, value } => write!(f,"Custom {{ description: {description} value: {value} }}"),
+            Payload::Custom { description, value:_ } => write!(f,"Custom {{ description: {description} }}"),
             Payload::Empty => write!(f,"Empty"),
         }
     }

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -50,12 +50,14 @@ async fn module_task(
                 if let Some(forbidden_dns) = &config.forbidden_dns {
                     if let Payload::DnsQuery { questions } = event.payload() {
                         if questions.iter().any(|question| &question.name == forbidden_dns) {
-                            let mut info = HashMap::new();
-                            info.insert("anomaly_score".to_string(), "1.0".to_string());
+                            let desc = "Forbidden DNS query".to_string();
+                            let mut extra = HashMap::new();
+                            extra.insert("anomaly_score".to_string(), "1.0".to_string());
 
                             sender.send_threat_derived(
                                 &event,
-                                info
+                                desc,
+                                Some(extra.into())
                             );
                         }
                     }


### PR DESCRIPTION
In the proprietary code-base we've encountered the issue where the extra data introduced in Threat::value or Payload::Custom::value could lead to extremely verbose output. In order to make is easier to read, we've introduced a `description` field, which contains a human-readable description of the threat.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
