### PR TITLE
Get user and group id related events

### DIFF
--- a/crates/bpf-builder/include/compatibility.bpf.h
+++ b/crates/bpf-builder/include/compatibility.bpf.h
@@ -38,6 +38,8 @@
 // __sync_fetch_and_add, __sync_fetch_and_sub etc.
 //
 // arm64 support was introduced in 5.18 with commit 1902472b4fa97.
+//
+// riscv support was introduced in 5.19.
 
 #if defined(__TARGET_ARCH_x86)
 #define HAVE_FEATURE_ATOMICS (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 12, 0))
@@ -46,5 +48,8 @@
 #elif defined(__TARGET_ARCH_riscv)
 #define HAVE_FEATURE_ATOMICS (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 19, 0))
 #else
+
+// Pulsar minimum supported kernel version is 5.5
+
 #define HAVE_FEATURE_ATOMICS false
 #endif

--- a/crates/bpf-builder/include/compatibility.bpf.h
+++ b/crates/bpf-builder/include/compatibility.bpf.h
@@ -27,21 +27,24 @@
 // Check these links for more details:
 // https://github.com/Exein-io/pulsar/issues/158
 // https://github.com/torvalds/linux/commit/69c087ba6225b574afb6e505b72cb75242a3d844
-//
-//
-// ## FEATURE_ATOMICS (since 5.12)
-//
-// Kernel 5.12 introduced support for atomic operations like
-// __sync_fetch_and_add, __sync_fetch_and_sub etc.
-//
 
 #ifdef VERSION_5_13
-
-#define FEATURE_ATOMICS
 #define FEATURE_FN_POINTERS
+#endif
 
+// ## FEATURE_ATOMICS (since 5.12)
+//
+// Kernel 5.12 introduced support for atomic operations in 86_64 like
+// __sync_fetch_and_add, __sync_fetch_and_sub etc.
+//
+// arm64 support was introduced in 5.18 with commit 1902472b4fa97.
+
+#if defined(__TARGET_ARCH_x86)
+#define HAVE_FEATURE_ATOMICS (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 12, 0))
+#elif defined(__TARGET_ARCH_arm64)
+#define HAVE_FEATURE_ATOMICS (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 18, 0))
+#elif defined(__TARGET_ARCH_riscv)
+#define HAVE_FEATURE_ATOMICS (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 19, 0))
 #else
-
-// Pulsar minimum supported kernel version is 5.5
-
+#define HAVE_FEATURE_ATOMICS false
 #endif

--- a/crates/bpf-builder/include/loop.bpf.h
+++ b/crates/bpf-builder/include/loop.bpf.h
@@ -14,25 +14,28 @@
 // Note: callback_fn must be declared as `static __always_inline` to satisfy the
 // verifier. For some reason, having this double call to the same non-inline
 // function seems to cause issues.
-#ifdef FEATURE_FN_POINTERS
-#define LOOP(max_iterations, max_unroll, callback_fn, ctx)                     \
-  if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_loop)) {           \
-    bpf_loop(max_iterations, callback_fn, ctx, 0);                             \
-  } else {                                                                     \
-    _Pragma("unroll") for (int i = 0; i < max_unroll; i++) {                   \
-      if (callback_fn(i, ctx) == LOOP_STOP)                                    \
-        break;                                                                 \
-    }                                                                          \
-  }
-#else
+
 // On kernel <= 5.13 taking the address of a function results in a verifier
 // error, even if inside a dead-code elimination branch.
-#define LOOP(max_iterations, max_unroll, callback_fn, ctx)                     \
-  _Pragma("unroll") for (int i = 0; i < max_unroll; i++) {                     \
-    if (callback_fn(i, ctx) == LOOP_STOP)                                      \
-      break;                                                                   \
-  }
-#endif
 
 #define LOOP_CONTINUE 0
 #define LOOP_STOP 1
+
+void LOOP(__u32 max_iterations, __u32 max_unroll, void *callback_fn, void *ctx)
+{
+#ifdef FEATURE_FN_POINTERS
+  if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_loop))
+  {
+    bpf_loop(max_iterations, callback_fn, ctx, 0);
+  }
+  else
+#endif
+  {
+#pragma unroll
+    for (int i = 0; i < max_unroll; i++)
+    {
+      if (((int (*)(int, void *))callback_fn)(i, ctx) == LOOP_STOP)
+        break;
+    }
+  }
+}

--- a/crates/bpf-common/src/feature_autodetect/kernel_version.rs
+++ b/crates/bpf-common/src/feature_autodetect/kernel_version.rs
@@ -8,7 +8,7 @@ use nix::fcntl::AtFlags;
 use nix::sys::utsname::uname;
 use nix::unistd::{faccessat, AccessFlags};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct KernelVersion {
     pub major: u32,
     pub minor: u32,

--- a/crates/bpf-common/src/lib.rs
+++ b/crates/bpf-common/src/lib.rs
@@ -31,6 +31,7 @@ pub fn log_error<E: std::error::Error + Send + Sync + 'static>(msg: &str, err: E
     log::error!("{}: {:?}", msg, anyhow::Error::from(err));
 }
 
+pub use nix::unistd::Gid;
 pub use nix::unistd::Pid;
 pub use nix::unistd::Uid;
 

--- a/crates/bpf-filtering/src/initializer.rs
+++ b/crates/bpf-filtering/src/initializer.rs
@@ -74,6 +74,7 @@ pub async fn setup_events_filter(
             ppid: process.parent,
             pid: process.pid,
             uid: process.uid,
+            gid: process.gid,
             timestamp: Timestamp::from(0),
             namespaces: process.namespaces,
             container_id: process.container_id.clone(),
@@ -97,6 +98,7 @@ pub async fn setup_events_filter(
                     pid,
                     ppid,
                     uid,
+                    gid,
                     namespaces,
                     container_id,
                     ..
@@ -104,6 +106,7 @@ pub async fn setup_events_filter(
                     *pid,
                     *ppid,
                     *uid,
+                    *gid,
                     *namespaces,
                     container_id.clone(),
                 )?)?,

--- a/crates/bpf-filtering/src/process_tree.rs
+++ b/crates/bpf-filtering/src/process_tree.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, path::Path};
 use bpf_common::{
     containers::ContainerId,
     parsing::procfs::{self, ProcfsError},
-    Pid, Uid,
+    Gid, Pid, Uid,
 };
 use lazy_static::lazy_static;
 use pulsar_core::event::Namespaces;
@@ -23,6 +23,7 @@ pub(crate) struct ProcessTree {
 pub(crate) struct ProcessData {
     pub(crate) pid: Pid,
     pub(crate) uid: Uid,
+    pub(crate) gid: Gid,
     pub(crate) image: String,
     pub(crate) parent: Pid,
     pub(crate) namespaces: Namespaces,
@@ -43,6 +44,7 @@ pub(crate) enum Error {
 
 pub(crate) const PID_0: Pid = Pid::from_raw(0);
 pub(crate) const UID_0: Uid = Uid::from_raw(0);
+pub(crate) const GID_0: Gid = Gid::from_raw(0);
 
 fn get_process_namespace(pid: Pid, ns_type: &str) -> Result<u32, Error> {
     let path = Path::new("/proc")
@@ -109,6 +111,7 @@ impl ProcessTree {
         // Get process list
         for pid in procfs::get_running_processes()? {
             let uid = procfs::get_process_user_id(pid)?;
+            let gid = procfs::get_process_group_id(pid)?;
 
             let image = procfs::get_process_image(pid)
                 .map(|path| path.to_string_lossy().to_string())
@@ -129,6 +132,7 @@ impl ProcessTree {
                 ProcessData {
                     pid,
                     uid,
+                    gid,
                     image,
                     parent,
                     namespaces,
@@ -146,6 +150,7 @@ impl ProcessTree {
             ProcessData {
                 pid: PID_0,
                 uid: UID_0,
+                gid: GID_0,
                 image: String::from("kernel"),
                 parent: PID_0,
                 namespaces,
@@ -185,6 +190,7 @@ impl ProcessTree {
         pid: Pid,
         ppid: Pid,
         uid: Uid,
+        gid: Gid,
         namespaces: Namespaces,
         container_id: Option<ContainerId>,
     ) -> Result<&ProcessData, Error> {
@@ -196,6 +202,7 @@ impl ProcessTree {
                 self.processes.push(ProcessData {
                     pid,
                     uid,
+                    gid,
                     image,
                     parent: ppid,
                     namespaces,

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -21,7 +21,7 @@ char LICENSE[] SEC("license") = "GPL v2";
 #define EVENT_CGROUP_ATTACH 6
 #define EVENT_CREDS_CHANGE 7
 
-#define MAX_ORPHANS 50
+#define MAX_ORPHANS 45
 #define MAX_ORPHANS_UNROLL 30
 
 #define MAX_PENDING_DEAD_PARENTS 30

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -651,3 +651,9 @@ static __always_inline void on_task_fix_setgid(void *ctx, struct cred *new,
                                                struct cred *old, int flags) {
   on_creds_change(ctx, new);
 }
+
+SEC("kprobe/commit_creds")
+int BPF_KPROBE(commit_creds, struct cred *new) {
+  on_creds_change(ctx, new);
+  return 0;
+}

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -54,6 +54,7 @@ struct namespaces
 struct fork_event
 {
   uid_t uid;
+  gid_t gid;
   pid_t ppid;
   struct namespaces namespaces;
   struct
@@ -257,6 +258,7 @@ int BPF_PROG(sched_process_fork, struct task_struct *parent,
   u64 uid_gid = bpf_get_current_uid_gid();
 
   event->fork.uid = uid_gid;
+  event->fork.gid = uid_gid >> 32;
   event->fork.ppid = parent_tgid;
   event->fork.namespaces.uts = BPF_CORE_READ(child, nsproxy, uts_ns, ns.inum);
   event->fork.namespaces.ipc = BPF_CORE_READ(child, nsproxy, ipc_ns, ns.inum);

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -79,6 +79,8 @@ pub struct Header {
     pub image: String,
     pub pid: i32,
     pub parent_pid: i32,
+    pub uid: u32,
+    pub gid: u32,
     pub container: Option<ContainerInfo>,
     #[validatron(skip)]
     pub threat: Option<Threat>,

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -10,10 +10,7 @@ use serde::{de::DeserializeOwned, ser, Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumString};
 use validatron::{Operator, Validatron, ValidatronError};
 
-use crate::{
-    kernel::{self},
-    pdk::ModuleName,
-};
+use crate::{kernel, pdk::ModuleName};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validatron)]
 pub struct Event {
@@ -207,6 +204,8 @@ pub enum Payload {
     },
     Fork {
         ppid: i32,
+        uid: u32,
+        gid: u32,
     },
     Exec {
         filename: String,
@@ -218,6 +217,10 @@ pub enum Payload {
     },
     ChangeParent {
         ppid: i32,
+    },
+    CredentialsChange {
+        uid: u32,
+        gid: u32,
     },
     CgroupCreated {
         cgroup_path: String,
@@ -298,10 +301,11 @@ impl fmt::Display for Payload {
             Payload::FileLink { source, destination, hard_link } => write!(f,"File Link {{ source: {source}, destination: {destination}, hard_link: {hard_link} }}"),
             Payload::FileRename { source, destination } => write!(f,"File Rename {{ source: {source}, destination {destination} }}"),
             Payload::ElfOpened { filename, flags } => write!(f,"Elf Opened {{ filename: {filename}, flags: {flags} }}"),
-            Payload::Fork { ppid } => write!(f,"Fork {{ ppid: {ppid} }}"),
+            Payload::Fork { ppid, uid, gid } => write!(f,"Fork {{ ppid: {ppid} uid: {uid} gid: {gid} }}"),
             Payload::Exec { filename, argc, argv } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv} }}"),
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
             Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
+            Payload::CredentialsChange { uid, gid } => write!(f,"Credentials changed {{ uid: {uid} gid: {gid} }}"),
             Payload::CgroupCreated { cgroup_path, cgroup_id } => write!(f,"Cgroup created {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),
             Payload::CgroupDeleted { cgroup_path, cgroup_id } => write!(f,"Cgroup deleted {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),
             Payload::CgroupAttach { cgroup_path, cgroup_id, attached_pid } => write!(f,"Process attached to cgroup {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id}, attached_pid {attached_pid} }}"),

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -247,6 +247,8 @@ impl ModuleSender {
                 pid: process.as_raw(),
                 timestamp: timestamp.into(),
                 image: String::new(),
+                uid: 0,
+                gid: 0,
                 parent_pid: 0,
                 fork_time: UNIX_EPOCH,
                 container: None,
@@ -259,11 +261,15 @@ impl ModuleSender {
                     argv: _,
                     namespaces: _,
                     container,
+                    uid,
+                    gid,
                 }) => {
                     header.image = image;
                     header.parent_pid = ppid.as_raw();
                     header.fork_time = fork_time.into();
                     header.container = container;
+                    header.uid = uid.as_raw();
+                    header.gid = gid.as_raw();
                 }
                 Err(e) => {
                     // warning: check if this actually happens or not


### PR DESCRIPTION
Started to work on #97:
- Added user and group id on fork event (using `bpf_get_current_uid_gid()`)
- Added hooks to intercept credentials change:
  - On LSM-supported kernels,`task_fix_set*id` calls are used
  - On kernel >= 5.10, we fall back on `security_task_fix_set*id`
  - On older kernels we fall back to commit_creds kprobe
- Testing on [architest](https://github.com/Exein-io/architest/releases/tag/0.3) virtual machines led me to discover some regression to to previous pull requests. I've fixed them and all tests are passing now.
- update process-tracker with the user id
- put those into header on event generation

To completely fix #97, the only item left is to:
- ~~add a mapping in process-tracker from user-id to username~~ <sup>not planned in this PR</sup>


# Credential changes syscalls

A small explanation on credentials-related system calls. User is changed with the `setuid` syscall, which invokes the LSM `task_fix_setuid` and calls `commit_creds`. The same for group changes: `setgid` leads to a call to `task_fix_setgid` and `commit_creds`.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
