### PR TITLE
Aya update 08-23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anstream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +171,7 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.11.0"
-source = "git+https://github.com/aya-rs/aya?rev=41fe944a1a60279705f5ed156b25675ea302e861#41fe944a1a60279705f5ed156b25675ea302e861"
+source = "git+https://github.com/aya-rs/aya?rev=761e4ddbe3abf8b9177ebd6984465fe66696728a#761e4ddbe3abf8b9177ebd6984465fe66696728a"
 dependencies = [
  "aya-obj",
  "bitflags 2.2.1",
@@ -182,11 +188,11 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?rev=41fe944a1a60279705f5ed156b25675ea302e861#41fe944a1a60279705f5ed156b25675ea302e861"
+source = "git+https://github.com/aya-rs/aya?rev=761e4ddbe3abf8b9177ebd6984465fe66696728a#761e4ddbe3abf8b9177ebd6984465fe66696728a"
 dependencies = [
  "bytes",
  "core-error",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "log",
  "object",
  "thiserror",
@@ -775,11 +781,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
  "ahash 0.8.3",
+ "allocator-api2",
 ]
 
 [[package]]

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -15,7 +15,7 @@ test-utils = [
 ]
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", rev = "41fe944a1a60279705f5ed156b25675ea302e861", features = ["async_tokio"] }
+aya = { git = "https://github.com/aya-rs/aya", rev = "761e4ddbe3abf8b9177ebd6984465fe66696728a", features = ["async_tokio"] }
 bytes = "1.3.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/bpf-common/src/program.rs
+++ b/crates/bpf-common/src/program.rs
@@ -246,8 +246,12 @@ impl ProgramBuilder {
             let mut bpf = BpfLoader::new()
                 .map_pin_path(&self.ctx.pinning_path)
                 .btf(Some(btf.as_ref()))
-                .set_global("log_level", &(self.ctx.log_level as i32))
-                .set_global("LINUX_KERNEL_VERSION", &self.ctx.kernel_version.as_i32())
+                .set_global("log_level", &(self.ctx.log_level as i32), true)
+                .set_global(
+                    "LINUX_KERNEL_VERSION",
+                    &self.ctx.kernel_version.as_i32(),
+                    true,
+                )
                 .load(&self.probe)?;
             for program in self.programs {
                 program.attach(&mut bpf, &btf)?;

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -89,7 +89,7 @@ struct {
 // This hook intercepts new process creations, inherits interest for the child
 // from the parent and emits a fork event.
 SEC("raw_tracepoint/sched_process_fork")
-int BPF_PROG(process_fork, struct task_struct *parent,
+int BPF_PROG(sched_process_fork, struct task_struct *parent,
              struct task_struct *child) {
   pid_t parent_tgid = BPF_CORE_READ(parent, tgid);
   pid_t child_tgid = BPF_CORE_READ(child, tgid);


### PR DESCRIPTION
This pr updates `aya` to the latest version

### Notes
now `aya` uses symbols in probes to find the program instead of section names. Only one program had problems and it has been solved making the name == section == tracepoint . Keep in mind we may have problems in future and we need to decouple the program name from the related tracepoint/kprobe/lsm name