### PR TITLE
build: Install libssl-dev in cross containers

### DIFF
--- a/.cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/.cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -1,6 +1,11 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    apt update && apt install -y \
+    libssl-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/aarch64-unknown-linux-musl.Dockerfile
+++ b/.cross/aarch64-unknown-linux-musl.Dockerfile
@@ -1,6 +1,11 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    apt update && apt install -y \
+    libssl-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
+++ b/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
@@ -1,6 +1,11 @@
 FROM ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    apt update && apt install -y \
+    libssl-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/.cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,6 +1,11 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    apt update && apt install -y \
+    libssl-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-musl.Dockerfile
+++ b/.cross/x86_64-unknown-linux-musl.Dockerfile
@@ -1,6 +1,11 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-    apt update && apt install -y lsb-release wget software-properties-common gnupg && \
+    apt update && apt install -y \
+    libssl-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip


### PR DESCRIPTION
CI is failing due to lack of OpenSSL headers, example:

https://github.com/Exein-io/pulsar/actions/runs/6119689300/job/16610104678?pr=198
