### PR TITLE
[187] Drop Lazy Static And Use Once Cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,6 @@ dependencies = [
  "cgroups-rs",
  "glob",
  "hex",
- "lazy_static",
  "libc",
  "log",
  "nix 0.26.2",
@@ -1292,9 +1291,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1340,7 +1339,6 @@ dependencies = [
  "env_logger",
  "file-system-monitor",
  "futures-util",
- "lazy_static",
  "log",
  "logger",
  "network-monitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ nix = "0.26.2"
 log = "0.4.14"
 anyhow = "1.0.53"
 clap = { version = "4.2.4", features = ["derive"] }
-lazy_static = "1.4.0"
 serde = "1.0.136"
 semver = { version = "1.0.4", features = ["serde"] }
 rust-ini = "0.17.0"

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -28,7 +28,6 @@ procfs = { version = "0.14.2", default-features = false }
 libc = "0.2"
 glob = "0.3.0"
 hex = "0.4.3"
-lazy_static = "1.4.0"
 
 # Test deps
 which = { version = "4.2.5", optional = true }

--- a/crates/bpf-common/src/platform/linux-aarch64/mod.rs
+++ b/crates/bpf-common/src/platform/linux-aarch64/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
-lazy_static! {
-    pub static ref SYSCALLS: HashMap<usize, &'static str> = {
+pub fn syscalls() -> &'static HashMap<usize, &'static str> {
+    static SYSCALLS: OnceLock<HashMap<usize, &'static str>> = OnceLock::new();
+
+    SYSCALLS.get_or_init(|| {
         let mut m = HashMap::new();
 
         m.insert(0, "IO_SETUP");
@@ -284,5 +286,5 @@ lazy_static! {
         m.insert(291, "STATX");
 
         m
-    };
+    })
 }

--- a/crates/bpf-common/src/platform/linux-armeabi/mod.rs
+++ b/crates/bpf-common/src/platform/linux-armeabi/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
-lazy_static! {
-    pub static ref SYSCALLS: HashMap<usize, &'static str> = {
+pub fn syscalls() -> &'static HashMap<usize, &'static str> {
+    static SYSCALLS: OnceLock<HashMap<usize, &'static str>> = OnceLock::new();
+
+    SYSCALLS.get_or_init(|| {
         let mut m = HashMap::new();
 
         m.insert(0, "RESTART_SYSCALL");
@@ -375,5 +377,5 @@ lazy_static! {
         m.insert(387, "EXECVEAT");
 
         m
-    };
+    })
 }

--- a/crates/bpf-common/src/platform/linux-riscv64/mod.rs
+++ b/crates/bpf-common/src/platform/linux-riscv64/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
-lazy_static! {
-    pub static ref SYSCALLS: HashMap<usize, &'static str> = {
+pub fn syscalls() -> &'static HashMap<usize, &'static str> {
+    static SYSCALLS: OnceLock<HashMap<usize, &'static str>> = OnceLock::new();
+
+    SYSCALLS.get_or_init(|| {
         let mut m = HashMap::new();
 
         m.insert(0, "IO_SETUP");
@@ -313,5 +315,5 @@ lazy_static! {
         m.insert(450, "SET_MEMPOLICY_HOME_NODE");
 
         m
-    };
+    })
 }

--- a/crates/bpf-common/src/platform/linux-x86/mod.rs
+++ b/crates/bpf-common/src/platform/linux-x86/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
-lazy_static! {
-    pub static ref SYSCALLS: HashMap<usize, &'static str> = {
+pub fn syscalls() -> &'static HashMap<usize, &'static str> {
+    static SYSCALLS: OnceLock<HashMap<usize, &'static str>> = OnceLock::new();
+
+    SYSCALLS.get_or_init(|| {
         let mut m = HashMap::new();
 
         m.insert(0, "RESTART_SYSCALL");
@@ -362,5 +364,5 @@ lazy_static! {
         m.insert(357, "BPF");
         m.insert(358, "EXECVEAT");
         m
-    };
+    })
 }

--- a/crates/bpf-common/src/platform/linux-x86_64/mod.rs
+++ b/crates/bpf-common/src/platform/linux-x86_64/mod.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
-use lazy_static::lazy_static;
+pub fn syscalls() -> &'static HashMap<usize, &'static str> {
+    static SYSCALLS: OnceLock<HashMap<usize, &'static str>> = OnceLock::new();
 
-lazy_static! {
-    pub static ref SYSCALLS: HashMap<usize, &'static str> = {
+    SYSCALLS.get_or_init(|| {
         let mut m = HashMap::new();
 
         m.insert(0, "READ");
@@ -331,5 +332,5 @@ lazy_static! {
         m.insert(322, "EXECVEAT");
 
         m
-    };
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 use std::env;
 
 use anyhow::Result;
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
 pub use pulsar_core::pdk::TaskLauncher;
 
@@ -70,16 +70,14 @@ pub mod pulsar;
 pub mod pulsard;
 
 pub(crate) fn version() -> &'static str {
+    static VERSION: OnceLock<String> = OnceLock::new();
     #[cfg(debug_assertions)]
-    lazy_static! {
-        static ref VERSION: String = format!("{}+dev", env!("CARGO_PKG_VERSION"));
-    }
+    let v = VERSION.get_or_init(|| format!("{}+dev", env!("CARGO_PKG_VERSION")));
 
     #[cfg(not(debug_assertions))]
-    lazy_static! {
-        static ref VERSION: String = env!("CARGO_PKG_VERSION").to_string();
-    }
-    &VERSION
+    let v = VERSION.get_or_init(|| env!("CARGO_PKG_VERSION").to_string());
+
+    v
 }
 
 pub fn modules() -> Vec<Box<dyn TaskLauncher>> {


### PR DESCRIPTION
# Drop Lazy Static and Use Once Cell

Removes lazy static from the crate and uses OnceLock instead of lazy_static!

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [ ] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).

resolves #187 
