### PR TITLE
[32] Allow modules to show warnings

### DIFF
--- a/crates/pulsar-core/src/pdk/daemon.rs
+++ b/crates/pulsar-core/src/pdk/daemon.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -150,9 +152,21 @@ impl PulsarDaemonHandle {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModuleStatus {
     Created,
-    Running,
+    Running(Vec<String>),
     Failed(String),
     Stopped,
+}
+
+impl fmt::Display for ModuleStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ModuleStatus::Running(warnings) if !warnings.is_empty() => {
+                write!(f, "Running([\"{}\"])", warnings.join("\",\""))
+            }
+            ModuleStatus::Running(_) => write!(f, "Running"),
+            _ => write!(f, "{:?}", self),
+        }
+    }
 }
 
 /// Messages used for internal communication between [`PulsarDaemonHandle`] and the underlying PulsarDaemon actor.

--- a/crates/pulsar-core/src/pdk/mod.rs
+++ b/crates/pulsar-core/src/pdk/mod.rs
@@ -14,7 +14,7 @@
 //! The [`ModuleContext`] is the entrypoint to access all the functions available to the module. It provides instances of:
 //! - [`ModuleSender`] to send events
 //! - [`ModuleReceiver`] to receive events
-//! - [`ErrorSender`] to raise unrecoverable errors
+//! - [`ModuleSignal`] to send signals, ex. raise unrecoverable errors, add warnings
 //! - [`tokio::sync::watch::Receiver`] to get the configuration
 //!
 //! Check specific structs for more informations.
@@ -26,7 +26,7 @@
 //! ```
 //! use pulsar_core::pdk::{
 //!     ModuleContext, Payload, PulsarModule, PulsarModuleTask, Version, CleanExit,
-//!     ShutdownSignal, ModuleError,
+//!     ShutdownSignal, ModuleError, ModuleSignal,
 //! };
 //! use tokio::time::{sleep, Duration};
 //!

--- a/crates/pulsar-core/src/pdk/module_context.rs
+++ b/crates/pulsar-core/src/pdk/module_context.rs
@@ -6,7 +6,7 @@ use tokio::sync::{broadcast, watch};
 
 use crate::{
     bus::Bus,
-    pdk::{ErrorSender, ModuleConfig, ModuleReceiver, ModuleSender, PulsarDaemonHandle},
+    pdk::{ModuleConfig, ModuleReceiver, ModuleSender, PulsarDaemonHandle, SignalSender},
 };
 
 use super::{process_tracker::ProcessTrackerHandle, ConfigError, ModuleError, ModuleName};
@@ -17,7 +17,7 @@ pub struct ModuleContext {
     module_name: ModuleName,
     cfg: watch::Receiver<ModuleConfig>,
     bus: Bus,
-    error_sender: ErrorSender,
+    signal_sender: SignalSender,
     daemon_handle: PulsarDaemonHandle,
     process_tracker: ProcessTrackerHandle,
     bpf_context: BpfContext,
@@ -29,7 +29,7 @@ impl ModuleContext {
         cfg: watch::Receiver<ModuleConfig>,
         bus: Bus,
         module_name: ModuleName,
-        error_sender: ErrorSender,
+        signal_sender: SignalSender,
         daemon_handle: PulsarDaemonHandle,
         process_tracker: ProcessTrackerHandle,
         bpf_context: BpfContext,
@@ -38,7 +38,7 @@ impl ModuleContext {
             cfg,
             bus,
             module_name,
-            error_sender,
+            signal_sender,
             daemon_handle,
             process_tracker,
             bpf_context,
@@ -90,7 +90,7 @@ impl ModuleContext {
             tx: self.bus.get_sender(),
             module_name: self.module_name.to_owned(),
             process_tracker: self.process_tracker.clone(),
-            error_sender: self.error_sender.clone(),
+            signal_sender: self.signal_sender.clone(),
         }
     }
 

--- a/src/pulsar/term_print.rs
+++ b/src/pulsar/term_print.rs
@@ -36,12 +36,13 @@ impl TermPrintable for Vec<ModuleOverview> {
         for module in sorted {
             let status_color = match module.status {
                 ModuleStatus::Created => Color::White,
-                ModuleStatus::Running => Color::Green,
+                ModuleStatus::Running(ref warnings) if warnings.is_empty() => Color::Green,
+                ModuleStatus::Running(_) => Color::Yellow,
                 ModuleStatus::Failed(_) => Color::Red,
                 ModuleStatus::Stopped => Color::Yellow,
             };
 
-            let status = format!("{:?}", module.status);
+            let status = format!("{}", module.status);
 
             table.add_row(vec![
                 Cell::new(module.name)


### PR DESCRIPTION
Allow modules to show warnings

## Implementation
Uses ctx to allow adding a warning to running status

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).

resolves #32 
