### PR TITLE
build: Disable stack protector

### DIFF
--- a/crates/bpf-builder/src/lib.rs
+++ b/crates/bpf-builder/src/lib.rs
@@ -47,6 +47,7 @@ fn compile(probe: &str, out_object: PathBuf, extra_args: &[&str]) -> anyhow::Res
         .args(["-target", "bpf"])
         .arg("-c")
         .arg("-Werror")
+        .arg("-fno-stack-protector")
         .arg(format!(
             "-D__TARGET_ARCH_{}",
             match arch.as_str() {


### PR DESCRIPTION
This option is not suppoted in BPF target, but some clang 16 installations try to enable it by default. Make sure it's always disabled.