### PR TITLE
feat(process-monitor): Include information about namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -292,9 +292,11 @@ dependencies = [
  "bpf-builder",
  "bpf-common",
  "cgroups-rs",
+ "lazy_static",
  "log",
  "nix 0.26.2",
  "pulsar-core",
+ "regex",
  "thiserror",
  "tokio",
  "which",
@@ -1156,7 +1158,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.28",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1280,9 +1282,9 @@ checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -1772,13 +1774,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-automata",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1786,6 +1800,12 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"

--- a/crates/bpf-filtering/Cargo.toml
+++ b/crates/bpf-filtering/Cargo.toml
@@ -23,6 +23,8 @@ bpf-common = { path = "../bpf-common" }
 pulsar-core = { path = "../pulsar-core" }
 which = { version = "4.2.5", optional = true }
 cgroups-rs = { version = "0.3.2", optional = true }
+regex = "1.9"
+lazy_static = "1.4"
 
 [build-dependencies]
 bpf-builder = { path = "../bpf-builder" }

--- a/crates/bpf-filtering/src/initializer.rs
+++ b/crates/bpf-filtering/src/initializer.rs
@@ -74,12 +74,14 @@ pub async fn setup_events_filter(
             ppid: process.parent,
             pid: process.pid,
             timestamp: Timestamp::from(0),
+            namespaces: process.namespaces,
         });
         process_tracker.update(TrackerUpdate::Exec {
             pid: process.pid,
             image: process.image.to_string(),
             timestamp: Timestamp::from(0),
             argv: Vec::new(),
+            namespaces: process.namespaces,
         });
     }
 

--- a/crates/bpf-filtering/src/process_tree.rs
+++ b/crates/bpf-filtering/src/process_tree.rs
@@ -1,10 +1,17 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fs, path::Path};
 
 use bpf_common::{
     parsing::procfs::{self, ProcfsError},
     Pid,
 };
+use lazy_static::lazy_static;
+use pulsar_core::event::Namespaces;
+use regex::Regex;
 use thiserror::Error;
+
+lazy_static! {
+    static ref NAMESPACE_RE: Regex = Regex::new(r"(\d+)").unwrap();
+}
 
 /// ProcessTree contains information about all running processes
 pub(crate) struct ProcessTree {
@@ -16,6 +23,7 @@ pub(crate) struct ProcessData {
     pub(crate) pid: Pid,
     pub(crate) image: String,
     pub(crate) parent: Pid,
+    pub(crate) namespaces: Namespaces,
 }
 
 #[derive(Debug, Error)]
@@ -24,16 +32,70 @@ pub(crate) enum Error {
     ProcessNotFound { pid: Pid },
     #[error("loading process {pid}: parent image {ppid} not found")]
     ParentNotFound { pid: Pid, ppid: Pid },
+    #[error(transparent)]
+    Procfs(#[from] ProcfsError),
+    #[error("failed to get the {ns_type} namespace for process {pid}")]
+    Namespace { pid: Pid, ns_type: String },
 }
 
 pub(crate) const PID_0: Pid = Pid::from_raw(0);
+
+fn get_process_namespace(pid: Pid, ns_type: &str) -> Result<u32, Error> {
+    let path = Path::new("/proc")
+        .join(pid.to_string())
+        .join("ns")
+        .join(ns_type);
+
+    let link_target = fs::read_link(path).map_err(|_| Error::Namespace {
+        pid,
+        ns_type: ns_type.to_owned(),
+    })?;
+    let link_target = link_target.to_string_lossy();
+    let ns: u32 = NAMESPACE_RE
+        .captures(&link_target)
+        .and_then(|cap| cap.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+        .ok_or(Error::Namespace {
+            pid,
+            ns_type: ns_type.to_owned(),
+        })?;
+
+    Ok(ns)
+}
+
+fn get_process_namespace_or_log(pid: Pid, namespace_type: &str) -> u32 {
+    get_process_namespace(pid, namespace_type).map_or_else(
+        |e| {
+            log::warn!(
+                "Failed to determine {} namespace for process {:?}: {}",
+                namespace_type,
+                pid,
+                e
+            );
+            u32::default()
+        },
+        |v| v,
+    )
+}
+
+fn get_process_namespaces(pid: Pid) -> Namespaces {
+    Namespaces {
+        uts: get_process_namespace_or_log(pid, "uts"),
+        ipc: get_process_namespace_or_log(pid, "ipc"),
+        mnt: get_process_namespace_or_log(pid, "mnt"),
+        net: get_process_namespace_or_log(pid, "net"),
+        pid: get_process_namespace_or_log(pid, "pid"),
+        time: get_process_namespace_or_log(pid, "time"),
+        cgroup: get_process_namespace_or_log(pid, "cgroup"),
+    }
+}
 
 impl ProcessTree {
     /// Construct the `ProcessTree` by reading from `procfs`:
     /// - process list
     /// - parent pid
     /// - image
-    pub(crate) fn load_from_procfs() -> Result<Self, ProcfsError> {
+    pub(crate) fn load_from_procfs() -> Result<Self, Error> {
         let mut processes: HashMap<Pid, ProcessData> = HashMap::new();
         let mut children: HashMap<Pid, Vec<Pid>> = HashMap::new();
         let mut sorted_processes: Vec<ProcessData> = Vec::new();
@@ -50,18 +112,29 @@ impl ProcessTree {
                 log::debug!("Error getting parent pid of {pid}: {}", err);
                 Pid::from_raw(1)
             });
-            processes.insert(pid, ProcessData { pid, image, parent });
+            let namespaces = get_process_namespaces(pid);
+            processes.insert(
+                pid,
+                ProcessData {
+                    pid,
+                    image,
+                    parent,
+                    namespaces,
+                },
+            );
             children.entry(parent).or_default().push(pid);
         }
 
         // Make sure to add PID 0 (which is part of kernel) to map_interest to avoid
         // warnings about missing entries.
+        let namespaces = get_process_namespaces(PID_0);
         processes.insert(
             PID_0,
             ProcessData {
                 pid: PID_0,
                 image: String::from("kernel"),
                 parent: PID_0,
+                namespaces,
             },
         );
 
@@ -97,10 +170,12 @@ impl ProcessTree {
         match parent {
             Some(parent) => {
                 let image = parent.image.to_string();
+                let namespaces = get_process_namespaces(pid);
                 self.processes.push(ProcessData {
                     pid,
                     image,
                     parent: ppid,
+                    namespaces,
                 });
                 Ok(self.processes.last().unwrap())
             }

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -158,11 +158,13 @@ pub enum Payload {
     },
     Fork {
         ppid: i32,
+        namespaces: Namespaces,
     },
     Exec {
         filename: String,
         argc: usize,
         argv: Argv,
+        namespaces: Namespaces,
     },
     Exit {
         exit_code: u32,
@@ -249,8 +251,8 @@ impl fmt::Display for Payload {
             Payload::FileLink { source, destination, hard_link } => write!(f,"File Link {{ source: {source}, destination: {destination}, hard_link: {hard_link} }}"),
             Payload::FileRename { source, destination } => write!(f,"File Rename {{ source: {source}, destination {destination} }}"),
             Payload::ElfOpened { filename, flags } => write!(f,"Elf Opened {{ filename: {filename}, flags: {flags} }}"),
-            Payload::Fork { ppid } => write!(f,"Fork {{ ppid: {ppid} }}"),
-            Payload::Exec { filename, argc, argv } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv} }}"),
+            Payload::Fork { ppid, namespaces } => write!(f,"Fork {{ ppid: {ppid}, namespaces: {namespaces} }}"),
+            Payload::Exec { filename, argc, argv, namespaces } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv}, namespaces: {namespaces} }}"),
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
             Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
             Payload::CgroupCreated { cgroup_path, cgroup_id } => write!(f,"Cgroup created {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),
@@ -475,6 +477,28 @@ impl From<Argv> for Vec<String> {
 impl fmt::Display for Argv {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         print_vec(f, &self.0)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Validatron)]
+pub struct Namespaces {
+    pub uts: u32,
+    pub ipc: u32,
+    pub mnt: u32,
+    pub pid: u32,
+    pub net: u32,
+    pub time: u32,
+    pub cgroup: u32,
+}
+
+impl fmt::Display for Namespaces {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{ uts: {}, ipc: {}, mnt: {}, pid: {}, net: {}, time: {}, cgroup: {} }}",
+            self.uts, self.ipc, self.mnt, self.pid, self.net, self.time, self.cgroup
+        )
     }
 }
 

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -243,6 +243,7 @@ impl ModuleSender {
                     ppid,
                     fork_time,
                     argv: _,
+                    namespaces: _,
                 }) => {
                     header.image = image;
                     header.parent_pid = ppid.as_raw();


### PR DESCRIPTION
This is a preparatory change for supporting container monitoring in Pulsar. Containers are just set of namespaces, so the easiest way to recognize that a process belongs to a particular container from information available from BPF programs, is to do that based on namespaces.

For now, we simply add information about all namespaces for each executed or forked process.
