### PR TITLE
rule_engine: check payload dicriminant before ruleset

### DIFF
--- a/.cross/README.md
+++ b/.cross/README.md
@@ -2,4 +2,7 @@
 
 These containers are used in conjunction with [cross](https://github.com/cross-rs/cross) to build Pulsar in a reproducible way without worrying about system dependencies. 
 
-Containers are based on the default [cross containers](https://github.com/orgs/cross-rs/packages) built from `Ubuntu 20.04 LTS`, with the addition of `Clang/LLVM 16`.
+Containers are based on the default [cross containers](https://github.com/orgs/cross-rs/packages) built from `Ubuntu 20.04 LTS`, with the addition of:
+
+-   `Clang/LLVM 16`
+-   `libssl-dev` speficic for the target architecture, example `libssl-dev:arm64`

--- a/.cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/.cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN dpkg --add-architecture arm64 && \
     ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-        apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:arm64 && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:arm64 && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/aarch64-unknown-linux-musl.Dockerfile
+++ b/.cross/aarch64-unknown-linux-musl.Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
 RUN dpkg --add-architecture arm64 && \
     ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-        apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:arm64 && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:arm64 && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
+++ b/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:main
 RUN dpkg --add-architecture riscv64 && \
     ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-        apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:riscv64 && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:riscv64 && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/.cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-        apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-musl.Dockerfile
+++ b/.cross/x86_64-unknown-linux-musl.Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
-        apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev && \
+    apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
     ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.33",
@@ -406,8 +406,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "unicode-width",
 ]
 
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1608,6 +1608,7 @@ dependencies = [
  "nix 0.26.2",
  "semver",
  "serde",
+ "strum 0.25.0",
  "thiserror",
  "tokio",
  "toml_edit",
@@ -2116,6 +2117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2136,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.33",
 ]
 
 [[package]]

--- a/crates/pulsar-core/Cargo.toml
+++ b/crates/pulsar-core/Cargo.toml
@@ -17,3 +17,4 @@ anyhow = "1.0.53"
 log = "0.4"
 thiserror = "1.0.30"
 nix = "0.26.2"
+strum = { version = "0.25", features = ["derive"] }

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use serde::{de::DeserializeOwned, ser, Deserialize, Serialize};
+use strum::{EnumDiscriminants, EnumString};
 use validatron::{Operator, Validatron, ValidatronError};
 
 use crate::{
@@ -121,8 +122,10 @@ impl<T: Into<toml_edit::easy::Value>> From<T> for Value {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validatron)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validatron, EnumDiscriminants)]
 #[serde(tag = "type", content = "content")]
+#[strum_discriminants(derive(EnumString, Hash))]
+#[strum_discriminants(name(PayloadDiscriminant))]
 pub enum Payload {
     FileCreated {
         filename: String,


### PR DESCRIPTION
This pr introduces a new `PayloadDiscriminant` type to capture the rule `type` field. 

Rulesets are stored per discriminant and tested after having checked the discriminant.

It also improves performances in case there are a lot of rules defined on a single payload type, because not these rules won't be checked for other types

Fix: #210 