### PR TITLE
feat(process-monitor): Detect new containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,15 +272,20 @@ dependencies = [
  "cgroups-rs",
  "glob",
  "hex",
+ "lazy_static",
  "libc",
  "log",
  "nix 0.26.2",
  "procfs",
  "rand",
+ "regex",
+ "serde",
+ "serde_json",
  "sys-mount",
  "thiserror",
  "tokio",
  "tokio-fd",
+ "validatron",
  "which",
 ]
 
@@ -1632,6 +1637,7 @@ dependencies = [
  "pulsar-core",
  "thiserror",
  "tokio",
+ "which",
 ]
 
 [[package]]

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -28,12 +28,17 @@ procfs = { workspace = true }
 libc = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+lazy_static = { workspace = true }
+regex = { workspace = true }
 
 # Test deps
 which = { workspace = true, optional = true }
 cgroups-rs = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 
+validatron = { workspace = true }
 
 [build-dependencies]
 bpf-builder = { workspace = true }

--- a/crates/bpf-common/src/parsing/containers.rs
+++ b/crates/bpf-common/src/parsing/containers.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     fs::File,
     io::{self, BufReader},
     process::Command,
@@ -144,5 +145,15 @@ impl ContainerInfo {
                 })
             }
         }
+    }
+}
+
+impl fmt::Display for ContainerInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{ id: {}, name: {}, image: {}, image_digest: {} }}",
+            self.id, self.name, self.image, self.image_digest
+        )
     }
 }

--- a/crates/bpf-common/src/parsing/containers.rs
+++ b/crates/bpf-common/src/parsing/containers.rs
@@ -1,0 +1,148 @@
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    process::Command,
+};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use validatron::Validatron;
+
+#[derive(Error, Debug)]
+pub enum ContainerError {
+    #[error("reading file {path} failed")]
+    ReadFile {
+        #[source]
+        source: io::Error,
+        path: String,
+    },
+    #[error("parsing config from `{path}` failed")]
+    ParseConfig {
+        #[source]
+        source: serde_json::error::Error,
+        path: String,
+    },
+    #[error("executing {command} failed")]
+    Exec {
+        #[source]
+        source: io::Error,
+        command: String,
+    },
+    #[error("executing {command} failed with status {code:?}")]
+    ExecStatus { command: String, code: Option<i32> },
+    #[error("parsing image digest {digest} failed")]
+    ParseDigest { digest: String },
+    #[error("invalid hash function {hash_fn}")]
+    InvalidHashFunction { hash_fn: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContainerId {
+    Docker(String),
+    Libpod(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerConfig {
+    #[serde(rename = "Config")]
+    config: DockerContainerConfig,
+    #[serde(rename = "Image")]
+    image_digest: String,
+    #[serde(rename = "Name")]
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerContainerConfig {
+    #[serde(rename = "Image")]
+    image: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LibpodConfig {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Image")]
+    image: String,
+    #[serde(rename = "ImageDigest")]
+    image_digest: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Validatron)]
+pub struct ContainerInfo {
+    pub id: String,
+    pub name: String,
+    pub image: String,
+    pub image_digest: String,
+}
+
+impl ContainerInfo {
+    pub fn from_container_id(id: ContainerId) -> Result<Self, ContainerError> {
+        match id {
+            ContainerId::Docker(id) => {
+                let path = format!("/var/lib/docker/containers/{}/config.v2.json", id);
+                let file = File::open(&path).map_err(|source| ContainerError::ReadFile {
+                    source,
+                    path: path.clone(),
+                })?;
+
+                let reader = BufReader::new(file);
+                let config: DockerConfig = serde_json::from_reader(reader)
+                    .map_err(|source| ContainerError::ParseConfig { source, path })?;
+
+                let name = config.name;
+                let name = if let Some(name) = name.strip_prefix('/') {
+                    name.to_owned()
+                } else {
+                    name
+                };
+                let image = config.config.image;
+                let image_digest = config.image_digest;
+
+                Ok(Self {
+                    id,
+                    name,
+                    image,
+                    image_digest,
+                })
+            }
+            ContainerId::Libpod(id) => {
+                let output = Command::new("podman")
+                    .arg("inspect")
+                    .arg("--type=container")
+                    .arg(&id)
+                    .output()
+                    .map_err(|source| ContainerError::Exec {
+                        source,
+                        command: "podman".to_owned(),
+                    })?;
+
+                if !output.status.success() {
+                    return Err(ContainerError::ExecStatus {
+                        command: "podman".to_owned(),
+                        code: output.status.code(),
+                    });
+                }
+
+                let config: LibpodConfig =
+                    serde_json::from_slice(&output.stdout).map_err(|source| {
+                        ContainerError::ParseConfig {
+                            source,
+                            path: format!("podman inspect --type=container {id}"),
+                        }
+                    })?;
+
+                let name = config.name;
+                let image = config.image;
+                let image_digest = config.image_digest;
+
+                Ok(Self {
+                    id,
+                    name,
+                    image,
+                    image_digest,
+                })
+            }
+        }
+    }
+}

--- a/crates/bpf-common/src/parsing/mod.rs
+++ b/crates/bpf-common/src/parsing/mod.rs
@@ -1,3 +1,4 @@
+pub mod containers;
 pub mod procfs;
 
 mod buffer_index;

--- a/crates/bpf-common/src/program.rs
+++ b/crates/bpf-common/src/program.rs
@@ -4,7 +4,8 @@
 //!
 use core::fmt;
 use std::{
-    collections::HashSet, convert::TryFrom, fmt::Display, mem::size_of, sync::Arc, time::Duration,
+    collections::HashSet, convert::TryFrom, fmt::Display, mem::size_of, path::PathBuf, sync::Arc,
+    time::Duration,
 };
 
 use aya::{
@@ -178,6 +179,11 @@ pub enum ProgramError {
     BtfError(#[from] BtfError),
     #[error("running background aya task {0}")]
     JoinError(#[from] JoinError),
+    #[error("could not find the inode of {path}")]
+    InodeError {
+        path: PathBuf,
+        io_error: Box<std::io::Error>,
+    },
 }
 
 pub struct ProgramBuilder {

--- a/crates/bpf-filtering/src/initializer.rs
+++ b/crates/bpf-filtering/src/initializer.rs
@@ -75,6 +75,7 @@ pub async fn setup_events_filter(
             pid: process.pid,
             timestamp: Timestamp::from(0),
             namespaces: process.namespaces,
+            is_new_container: false,
         });
         process_tracker.update(TrackerUpdate::Exec {
             pid: process.pid,
@@ -82,6 +83,7 @@ pub async fn setup_events_filter(
             timestamp: Timestamp::from(0),
             argv: Vec::new(),
             namespaces: process.namespaces,
+            is_new_container: false,
         });
     }
 

--- a/crates/modules/process-monitor/Cargo.toml
+++ b/crates/modules/process-monitor/Cargo.toml
@@ -18,6 +18,7 @@ nix = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+which = { workspace = true }
 
 [build-dependencies]
 bpf-builder = { workspace = true }

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -72,14 +72,14 @@ pub enum ProcessEvent {
     Fork {
         ppid: Pid,
         namespaces: Namespaces,
-        is_new_container: u32,
+        is_new_container: bool,
     },
     Exec {
         filename: BufferIndex<str>,
         argc: u32,
         argv: BufferIndex<str>, // 0 separated strings
         namespaces: Namespaces,
-        is_new_container: u32,
+        is_new_container: bool,
     },
     Exit {
         exit_code: u32,
@@ -153,16 +153,13 @@ pub mod pulsar {
                         ppid,
                         namespaces,
                         is_new_container,
-                    } => {
-                        let is_new_container = is_new_container == 1;
-                        TrackerUpdate::Fork {
-                            pid: event.pid,
-                            ppid,
-                            timestamp: event.timestamp,
-                            namespaces,
-                            is_new_container,
-                        }
-                    }
+                    } => TrackerUpdate::Fork {
+                        pid: event.pid,
+                        ppid,
+                        timestamp: event.timestamp,
+                        namespaces,
+                        is_new_container,
+                    },
                     ProcessEvent::Exec {
                         ref filename,
                         argc,
@@ -183,7 +180,6 @@ pub mod pulsar {
                                 event.pid
                             )
                         }
-                        let is_new_container = is_new_container == 1;
                         TrackerUpdate::Exec {
                             pid: event.pid,
                             // ignoring this error since it will be catched in IntoPayload
@@ -244,7 +240,6 @@ pub mod pulsar {
                     is_new_container,
                     ..
                 } => {
-                    let is_new_container = is_new_container == 1;
                     let container = match procfs::get_process_container_id(pid) {
                         Ok(Some(container_id)) => {
                             Some(ContainerInfo::from_container_id(container_id)?)
@@ -268,7 +263,6 @@ pub mod pulsar {
                     is_new_container,
                     ..
                 } => {
-                    let is_new_container = is_new_container == 1;
                     let container = match procfs::get_process_container_id(pid) {
                         Ok(Some(container_id)) => {
                             Some(ContainerInfo::from_container_id(container_id)?)

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -297,8 +297,14 @@ impl fmt::Display for Payload {
             Payload::FileLink { source, destination, hard_link } => write!(f,"File Link {{ source: {source}, destination: {destination}, hard_link: {hard_link} }}"),
             Payload::FileRename { source, destination } => write!(f,"File Rename {{ source: {source}, destination {destination} }}"),
             Payload::ElfOpened { filename, flags } => write!(f,"Elf Opened {{ filename: {filename}, flags: {flags} }}"),
-            Payload::Fork { ppid, namespaces, is_new_container, container } => write!(f,"Fork {{ ppid: {ppid}, namespaces: {namespaces}, is_new_container: {is_new_container}, container: {container:?} }}"),
-            Payload::Exec { filename, argc, argv, namespaces, is_new_container, container } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv}, namespaces: {namespaces}, is_new_container: {is_new_container}, container: {container:?} }}"),
+            Payload::Fork { ppid, container, .. } => match container {
+                Some(container) => write!(f,"Fork {{ ppid: {ppid}, container: {container} }}"),
+                None => write!(f,"Fork {{ ppid: {ppid} }}"),
+            },
+            Payload::Exec { filename, argc, argv, container, .. } => match container {
+                Some(container) => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv}, container: {container} }}"),
+                None => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv} }}"),
+            },
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
             Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
             Payload::CgroupCreated { cgroup_path, cgroup_id } => write!(f,"Cgroup created {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -73,7 +73,7 @@ pub struct Header {
     pub pid: i32,
     pub parent_pid: i32,
     #[validatron(skip)]
-    pub container_id: Option<String>,
+    pub container: Option<ContainerInfo>,
     #[validatron(skip)]
     pub threat: Option<Threat>,
     pub source: ModuleName,

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -212,10 +212,6 @@ pub enum Payload {
         #[validatron(skip)]
         container: Option<ContainerInfo>,
     },
-    Container {
-        info: ContainerInfo,
-        namespaces: Namespaces,
-    },
     Exit {
         exit_code: u32,
     },
@@ -303,7 +299,6 @@ impl fmt::Display for Payload {
             Payload::ElfOpened { filename, flags } => write!(f,"Elf Opened {{ filename: {filename}, flags: {flags} }}"),
             Payload::Fork { ppid, namespaces, is_new_container, container } => write!(f,"Fork {{ ppid: {ppid}, namespaces: {namespaces}, is_new_container: {is_new_container}, container: {container:?} }}"),
             Payload::Exec { filename, argc, argv, namespaces, is_new_container, container } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv}, namespaces: {namespaces}, is_new_container: {is_new_container}, container: {container:?} }}"),
-            Payload::Container { info, namespaces } => write!(f,"Container {{ id: {}, image: {}, image_digest: {}, namespaces: {namespaces} }}", info.id, info.image, info.image_digest),
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
             Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
             Payload::CgroupCreated { cgroup_path, cgroup_id } => write!(f,"Cgroup created {{ cgroup_path: {cgroup_path}, cgroup_id: {cgroup_id} }}"),

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -245,7 +245,7 @@ impl ModuleSender {
                 image: String::new(),
                 parent_pid: 0,
                 fork_time: UNIX_EPOCH,
-                container_id: None,
+                container: None,
             };
             match process_tracker.get(process, timestamp).await {
                 Ok(ProcessInfo {
@@ -259,9 +259,7 @@ impl ModuleSender {
                     header.image = image;
                     header.parent_pid = ppid.as_raw();
                     header.fork_time = fork_time.into();
-                    if let Some(container) = container {
-                        header.container_id = Some(container.id);
-                    }
+                    header.container = container;
                 }
                 Err(e) => {
                     // warning: check if this actually happens or not

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -245,6 +245,7 @@ impl ModuleSender {
                 image: String::new(),
                 parent_pid: 0,
                 fork_time: UNIX_EPOCH,
+                container_id: None,
             };
             match process_tracker.get(process, timestamp).await {
                 Ok(ProcessInfo {
@@ -253,10 +254,14 @@ impl ModuleSender {
                     fork_time,
                     argv: _,
                     namespaces: _,
+                    container,
                 }) => {
                     header.image = image;
                     header.parent_pid = ppid.as_raw();
                     header.fork_time = fork_time.into();
+                    if let Some(container) = container {
+                        header.container_id = Some(container.id);
+                    }
                 }
                 Err(e) => {
                     // warning: check if this actually happens or not


### PR DESCRIPTION
Enhance the process monitor with an ability to detect when a
container runtime creates a new mount namespace, which we can consider
as a creation of a new container.

Achieve that by:

* Registering the inodes of container runtime binaries we want to
  track in the user-space, saving them in a BPF map.
* In BPF, every time a process is being executed using the runtime
  binary, checking whether the PID namespace was changed.