### PR TITLE
chore: Define dependencies in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,25 +1774,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1803,9 +1803,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,29 +15,29 @@ path = "src/main.rs"
 
 [dependencies]
 # Crates
-bpf-common = { path = "crates/bpf-common" }
-engine-api = { path = "crates/engine-api" }
-pulsar-core = { path = "crates/pulsar-core" }
+bpf-common = { workspace = true }
+engine-api = { workspace = true }
+pulsar-core = { workspace = true }
 # Modules
-file-system-monitor = { path = "crates/modules/file-system-monitor", optional = true }
-process-monitor = { path = "crates/modules/process-monitor", optional = true }
-network-monitor = { path = "crates/modules/network-monitor", optional = true }
-logger = { path = "crates/modules/logger", optional = true }
-rules-engine = { path = "crates/modules/rules-engine", optional = true }
-desktop-notifier = { path = "crates/modules/desktop-notifier", optional = true }
-smtp-notifier = { path = "crates/modules/smtp-notifier", optional = true }
+desktop-notifier = { workspace = true, optional = true }
+file-system-monitor = { workspace = true, optional = true }
+logger = { workspace = true, optional = true }
+network-monitor = { workspace = true, optional = true }
+process-monitor = { workspace = true, optional = true }
+rules-engine = { workspace = true, optional = true }
+smtp-notifier = { workspace = true, optional = true }
 # External
-tokio = { version = "1.15.0", features = ["full"] }
-env_logger = "0.10.0"
-nix = "0.26.2"
-log = "0.4.14"
-anyhow = "1.0.53"
-clap = { version = "4.2.4", features = ["derive"] }
-serde = "1.0.136"
-semver = { version = "1.0.4", features = ["serde"] }
-rust-ini = "0.17.0"
-comfy-table = "5.0.1"
-futures-util = "0.3.25"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+comfy-table = { workspace = true }
+env_logger = { workspace = true }
+futures-util = { workspace = true }
+log = { workspace = true }
+nix = { workspace = true }
+rust-ini = { workspace = true }
+serde = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["full"]
@@ -70,6 +70,76 @@ version = "0.6.0"
 license = "Apache-2.0 WITH BPF probes exception under GPL-2.0"
 edition = "2021"
 repository = "https://github.com/Exein-io/pulsar"
+
+[workspace.dependencies]
+# Crates
+bpf-builder = { path = "crates/bpf-builder" }
+bpf-common = { path = "crates/bpf-common", features = ["test-utils", "test-suite"] }
+bpf-filtering = { path = "crates/bpf-filtering", features = ["test-suite"] }
+engine-api = { path = "crates/engine-api" }
+pulsar-core = { path = "crates/pulsar-core" }
+# Modules
+desktop-notifier = { path = "crates/modules/desktop-notifier" }
+file-system-monitor = { path = "crates/modules/file-system-monitor", features = ["test-suite"] }
+logger = { path = "crates/modules/logger" }
+network-monitor = { path = "crates/modules/network-monitor", features = ["test-suite"] }
+process-monitor = { path = "crates/modules/process-monitor", features = ["test-suite"] }
+rules-engine = { path = "crates/modules/rules-engine" }
+smtp-notifier = { path = "crates/modules/smtp-notifier" }
+# External
+anyhow = "1"
+aya = { git = "https://github.com/aya-rs/aya", rev = "761e4ddbe3abf8b9177ebd6984465fe66696728a", features = ["async_tokio"] }
+axum = { version = "0.6.20", features = ["ws"] }
+bytes = "1.3.0"
+cgroups-rs = { version = "0.3.2" }
+chrono = { version = "0.4.31" }
+clap = { version = "4.2.4", features = ["derive"] }
+comfy-table = "5.0.1"
+dns-parser = "0.8.0"
+env_logger = "0.10.0"
+futures = "0.3.21"
+futures-util = "0.3.25"
+gethostname = "0.4.3"
+glob = "0.3.0"
+hex = "0.4.3"
+hyper = "0.14.17"
+hyperlocal = "0.8"
+lalrpop = "0.19.9"
+lalrpop-util = { version="0.19.9", features=["lexer"] }
+lazy_static = "1.4"
+leon = "2.0.1"
+lettre = { version = "0.10.4", default-features = false, features = ["smtp-transport", "tokio1-native-tls", "tokio1", "builder"] }
+libc = "0.2"
+libtest-mimic =  "0.6.0"
+log = "0.4"
+nix = { version = "0.26.2", features = ["fs"] }
+num_cpus = "1.16"
+openssl = { version = "0.10.57" }
+proc-macro2 = "1.0"
+procfs = { version = "0.14.2", default-features = false }
+quote = "1.0"
+rand = { version = "0.8.5" }
+regex = "1.10"
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+rust-ini = "0.17.0"
+semver = { version = "1.0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.79"
+serde_yaml = "0.9.21"
+signal-hook = "0.3.14"
+strum = { version = "0.25", features = ["derive"] }
+syn = { version = "2.0" }
+sys-mount = {version = "1.5.1", default-features = false}
+thiserror = "1"
+toml_edit = { version = "0.15.0", features = ["easy"] }
+tokio = { version = "1", features = ["full"] }
+tokio-fd = "0.3.0"
+tokio-tungstenite = "0.20.1"
+uuid = { version = "1.4", features = ["v4"] }
+validatron = { path = "crates/validatron" }
+validatron-derive = { path = "crates/validatron/derive" }
+which = { version = "4.2.5" }
+xshell = "0.2.2"
 
 [profile.release]
 lto = true

--- a/crates/bpf-builder/Cargo.toml
+++ b/crates/bpf-builder/Cargo.toml
@@ -6,4 +6,4 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -15,25 +15,25 @@ test-utils = [
 ]
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", rev = "761e4ddbe3abf8b9177ebd6984465fe66696728a", features = ["async_tokio"] }
-bytes = "1.3.0"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-fd = "0.3.0"
-log = "0.4"
-anyhow = "1"
-nix = { version = "0.26.2", features = ["fs"] }
-sys-mount = {version = "1.5.1", default-features = false}
-procfs = { version = "0.14.2", default-features = false }
-libc = "0.2"
-glob = "0.3.0"
-hex = "0.4.3"
+aya = { workspace = true, features = ["async_tokio"] }
+bytes = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-fd = { workspace = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
+sys-mount = { workspace = true }
+procfs = { workspace = true }
+libc = { workspace = true }
+glob = { workspace = true }
+hex = { workspace = true }
 
 # Test deps
-which = { version = "4.2.5", optional = true }
-cgroups-rs = { version = "0.3.2", optional = true }
-rand = { version = "0.8.5", optional = true }
+which = { workspace = true, optional = true }
+cgroups-rs = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 
 
 [build-dependencies]
-bpf-builder = { path = "../bpf-builder" }
+bpf-builder = { workspace = true }

--- a/crates/bpf-filtering/Cargo.toml
+++ b/crates/bpf-filtering/Cargo.toml
@@ -14,17 +14,17 @@ test-suite = [
 ]
 
 [dependencies]
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-log = "0.4"
-anyhow = "1"
-nix = { version = "0.26.2", features = ["fs"] }
-bpf-common = { path = "../bpf-common" }
-pulsar-core = { path = "../pulsar-core" }
-which = { version = "4.2.5", optional = true }
-cgroups-rs = { version = "0.3.2", optional = true }
-regex = "1.9"
-lazy_static = "1.4"
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+log = { workspace = true }
+anyhow = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
+bpf-common = { workspace = true }
+pulsar-core = { workspace = true }
+regex = { workspace = true }
+which = { workspace = true, optional = true }
+cgroups-rs = { workspace = true, optional = true }
+lazy_static = { workspace = true }
 
 [build-dependencies]
-bpf-builder = { path = "../bpf-builder" }
+bpf-builder = { workspace = true }

--- a/crates/engine-api/Cargo.toml
+++ b/crates/engine-api/Cargo.toml
@@ -6,16 +6,16 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-pulsar-core = { path = "../pulsar-core" }
-log = "0.4"
-libc = "0.2"
-axum = { version = "0.6.20", features = ["ws"] }
-anyhow = "1.0.53"
-serde = { version = "1.0.136", features = ["derive"] }
-tokio = "1.15.0"
-hyper = "0.14.17"
-futures = "0.3.21"
-hyperlocal = "0.8"
-serde_json = "1.0.79"
-tokio-tungstenite = "0.20.1"
-thiserror = "1.0.38"
+pulsar-core = { workspace = true }
+log = { workspace = true }
+libc = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true }
+hyper = { workspace = true }
+futures = { workspace = true }
+hyperlocal = { workspace = true }
+serde_json = { workspace = true }
+tokio-tungstenite = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/modules/desktop-notifier/Cargo.toml
+++ b/crates/modules/desktop-notifier/Cargo.toml
@@ -6,9 +6,9 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-pulsar-core = { path = "../../pulsar-core" }
-bpf-common = { path = "../../bpf-common" }
+pulsar-core = { workspace = true }
+bpf-common = { workspace = true }
 
-tokio = { version = "1", features = ["full"] }
-log = "0.4"
-anyhow = "1.0.68"
+tokio = { workspace = true, features = ["full"] }
+log = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/modules/file-system-monitor/Cargo.toml
+++ b/crates/modules/file-system-monitor/Cargo.toml
@@ -9,12 +9,12 @@ repository.workspace = true
 test-suite = ["bpf-common/test-utils"]
 
 [dependencies]
-bpf-common = { path = "../../bpf-common" }
-pulsar-core = { path = "../../pulsar-core" }
+bpf-common = { workspace = true }
+pulsar-core = { workspace = true }
 
-nix = "0.26.2"
-tokio = { version = "1", features = ["full"] }
-log = "0.4"
+nix = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+log = { workspace = true }
 
 [build-dependencies]
-bpf-builder = { path = "../../bpf-builder" }
+bpf-builder = { workspace = true }

--- a/crates/modules/logger/Cargo.toml
+++ b/crates/modules/logger/Cargo.toml
@@ -6,9 +6,9 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-pulsar-core = { path = "../../pulsar-core" }
-bpf-common = { path = "../../bpf-common" }
+pulsar-core = { workspace = true }
+bpf-common = { workspace = true }
 
-tokio = { version = "1", features = ["full"] }
-log = "0.4"
-chrono = { version = "0.4.23", features = ["std"], default-features = false }
+tokio = { workspace = true, features = ["full"] }
+log = { workspace = true }
+chrono = { workspace = true, features = ["std"] }

--- a/crates/modules/network-monitor/Cargo.toml
+++ b/crates/modules/network-monitor/Cargo.toml
@@ -9,13 +9,13 @@ repository.workspace = true
 test-suite = ["bpf-common/test-utils"]
 
 [dependencies]
-bpf-common = { path = "../../bpf-common" }
-pulsar-core = { path = "../../pulsar-core" }
+bpf-common = { workspace = true }
+pulsar-core = { workspace = true }
 
-tokio = { version = "1", features = ["full"] }
-log = "0.4"
-nix = "0.26.2"
-dns-parser = "0.8.0"
+tokio = { workspace = true, features = ["full"] }
+log = { workspace = true }
+nix = { workspace = true }
+dns-parser = { workspace = true }
 
 [build-dependencies]
-bpf-builder = { path = "../../bpf-builder" }
+bpf-builder = { workspace = true }

--- a/crates/modules/process-monitor/Cargo.toml
+++ b/crates/modules/process-monitor/Cargo.toml
@@ -9,15 +9,15 @@ repository.workspace = true
 test-suite = [ "bpf-common/test-utils" ]
 
 [dependencies]
-bpf-common = { path = "../../bpf-common" }
-bpf-filtering = { path = "../../bpf-filtering" }
-pulsar-core = { path = "../../pulsar-core" }
+bpf-common = { workspace = true }
+bpf-filtering = { workspace = true }
+pulsar-core = { workspace = true }
 
-tokio = { version = "1", features = ["full"] }
-nix = "0.26.2"
-log = "0.4"
-thiserror = "1"
-anyhow = "1.0.65"
+tokio = { workspace = true, features = ["full"] }
+nix = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
 
 [build-dependencies]
-bpf-builder = { path = "../../bpf-builder" }
+bpf-builder = { workspace = true }

--- a/crates/modules/rules-engine/Cargo.toml
+++ b/crates/modules/rules-engine/Cargo.toml
@@ -6,17 +6,17 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-validatron = { path = "../../validatron" }
-pulsar-core = { path = "../../pulsar-core" }
+validatron = { workspace = true }
+pulsar-core = { workspace = true }
 
-log = "0.4.17"
-anyhow = "1"
-tokio = "1.15.0"
-glob = "0.3.1"
-thiserror = "1.0.40"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_yaml = "0.9.21"
-lalrpop-util = { version="0.19.9", features=["lexer"] }
+log = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true }
+glob = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_yaml = { workspace = true }
+lalrpop-util = { workspace = true, features=["lexer"] }
 
 [build-dependencies]
-lalrpop = "0.19.9"
+lalrpop = { workspace = true }

--- a/crates/modules/smtp-notifier/Cargo.toml
+++ b/crates/modules/smtp-notifier/Cargo.toml
@@ -6,21 +6,21 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-pulsar-core = { path = "../../pulsar-core" }
+pulsar-core = { workspace = true }
 
-tokio = { version = "1", features = ["full"] }
-anyhow = "1.0"
-lettre = { version = "0.10.4", default-features = false, features = [
+tokio = { workspace = true, features = ["full"] }
+anyhow = { workspace = true }
+lettre = { workspace = true, features = [
     "smtp-transport",
     "tokio1-native-tls",
     "tokio1",
     "builder",
 ] }
-openssl = { version = "0.10.57" }
-leon = "2.0.1"
-gethostname = "0.4.3"
-chrono = { version = "0.4.31" }
-rand = "0.8.5"
+openssl = { workspace = true }
+leon = { workspace = true }
+gethostname = { workspace = true }
+chrono = { workspace = true }
+rand = { workspace = true }
 
 [features]
 openssl-vendored = ["openssl/vendored"]

--- a/crates/pulsar-core/Cargo.toml
+++ b/crates/pulsar-core/Cargo.toml
@@ -9,12 +9,12 @@ repository.workspace = true
 bpf-common = { path = "../bpf-common" }
 validatron = { path = "../validatron" }
 
-serde = { version = "1.0.136", features = ["derive"] }
-toml_edit = { version = "0.15.0", features = ["easy"] }
-tokio = { version = "1", features = ["full"] }
-semver = { version = "1.0.4", features = ["serde"] }
-anyhow = "1.0.53"
-log = "0.4"
-thiserror = "1.0.30"
-nix = "0.26.2"
-strum = { version = "0.25", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+toml_edit = { workspace = true, features = ["easy"] }
+tokio = { workspace = true, features = ["full"] }
+semver = { workspace = true, features = ["serde"] }
+anyhow = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+nix = { workspace = true }
+strum = { workspace = true, features = ["derive"] }

--- a/crates/validatron/Cargo.toml
+++ b/crates/validatron/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-serde = { version = "1.0.160", features = ["derive"] }
-log = "0.4.17"
-thiserror = "1.0.40"
-validatron-derive = {path = "derive"}
+serde = { workspace = true, features = ["derive"] }
+log = { workspace = true }
+thiserror = { workspace = true }
+validatron-derive = { workspace = true }

--- a/crates/validatron/derive/Cargo.toml
+++ b/crates/validatron/derive/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0" }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -6,13 +6,13 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-bpf-common = { path = "../crates/bpf-common", features = ["test-utils", "test-suite"] }
-bpf-filtering = { path = "../crates/bpf-filtering", features = ["test-suite"] }
-file-system-monitor = { path = "../crates/modules/file-system-monitor", features = ["test-suite"] }
-network-monitor = { path = "../crates/modules/network-monitor", features = ["test-suite"] }
-process-monitor = { path = "../crates/modules/process-monitor", features = ["test-suite"] }
-libtest-mimic =  "0.6.0"
-tokio = { version = "1", features = ["full"] }
-log = { version = "0.4", features = ["std"] }
-futures = "0.3.21"
-nix = "0.26.2"
+bpf-common = { workspace = true }
+bpf-filtering = { workspace = true }
+file-system-monitor = { workspace = true }
+network-monitor = { workspace = true }
+process-monitor = { workspace = true }
+libtest-mimic =  { workspace = true }
+tokio = { workspace = true }
+log = { workspace = true }
+futures = { workspace = true }
+nix = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,11 +6,11 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0.58"
-clap = { version = "4.2.4", features = ["derive"] }
-num_cpus = "1.16"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-serde = { version = "1.0", features = ["derive"] }
-signal-hook = "0.3.14"
-uuid = { version = "1.4", features = ["v4"] }
-xshell = "0.2.2"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+num_cpus = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["blocking", "json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+signal-hook = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+xshell = { workspace = true }


### PR DESCRIPTION
Use workspace-defined dependencies to avoid version differences across crates.
