### PR TITLE
chore: Link with clang/lld

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,52 @@
 [alias]
 xtask = "run --package xtask --"
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+  "-C",
+  "linker=clang",
+  "-C",
+  "link-arg=-fuse-ld=lld",
+  "-C",
+  "link-arg=--target=x86_64-unknown-linux-gnu"
+]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C",
+  "linker=clang",
+  "-C",
+  "link-arg=-fuse-ld=lld",
+  "-C",
+  "link-arg=--target=x86_64-unknown-linux-musl"
+]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = [
+  "-C",
+  "linker=clang",
+  "-C",
+  "link-arg=-fuse-ld=lld",
+  "-C",
+  "link-arg=--target=aarch64-unknown-linux-gnu"
+]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = [
+  "-C",
+  "linker=clang",
+  "-C",
+  "link-arg=-fuse-ld=lld",
+  "-C",
+  "link-arg=--target=aarch64-unknown-linux-musl"
+]
+
+[target.riscv64gc-unknown-linux-gnu]
+rustflags = [
+  "-C",
+  "linker=clang",
+  "-C",
+  "link-arg=-fuse-ld=lld",
+  "-C",
+  "link-arg=--target=riscv64-unknown-linux-gnu"
+]

--- a/.cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/.cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN dpkg --add-architecture arm64 && \
     ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
     apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:arm64 && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
-    ln -s /usr/bin/clang-16 /usr/bin/clang && \
-    ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && \
+    ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip

--- a/.cross/aarch64-unknown-linux-musl.Dockerfile
+++ b/.cross/aarch64-unknown-linux-musl.Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
 RUN dpkg --add-architecture arm64 && \
     ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
     apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:arm64 && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
-    ln -s /usr/bin/clang-16 /usr/bin/clang && \
-    ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && \
+    ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip

--- a/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
+++ b/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:main
 RUN dpkg --add-architecture riscv64 && \
     ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
     apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev:riscv64 && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
-    ln -s /usr/bin/clang-16 /usr/bin/clang && \
-    ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && \
+    ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/.cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
     apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
-    ln -s /usr/bin/clang-16 /usr/bin/clang && \
-    ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && \
+    ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-musl.Dockerfile
+++ b/.cross/x86_64-unknown-linux-musl.Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
 RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome > /etc/timezone && \
     apt update && apt install -y lsb-release wget software-properties-common gnupg libssl-dev && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16 && \
-    ln -s /usr/bin/clang-16 /usr/bin/clang && \
-    ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && \
+    ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip


### PR DESCRIPTION
Latest CI failures are connected to the fact that Rust 1.73 is
using new toolchains, which results in ld linker errors.

However, in this PR, we fix the linker errors by switching to lld,
because apart from fixing the original issue, it also speeds up
the build.

Also, since the new Rust is using LLVM 17, use LLVM 17 for building
our C probes as well.