### PR TITLE
feat: Make it clear which modules are enabled by default

### DIFF
--- a/crates/modules/desktop-notifier/README.md
+++ b/crates/modules/desktop-notifier/README.md
@@ -23,15 +23,15 @@ To make sure your system is compatible, check the output of `id -u`,
 
 ```ini
 [desktop-notifier]
-enabled=true
+enabled=false
 user_id=1000
 display=:0
 notify_send_executable=notify-send
 bus_address=unix:path=/run/user/1000/bus
 ```
 
-You disable this module with:
+This module is disabled by default. You can enable it with:
 
 ```sh
-pulsar config --set desktop-notifier.enabled=false
+pulsar config --set desktop-notifier.enabled=true
 ```

--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -19,6 +19,7 @@ pub fn module() -> PulsarModule {
     PulsarModule::new(
         MODULE_NAME,
         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        false,
         desktop_nitifier_task,
     )
 }

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -93,6 +93,7 @@ pub mod pulsar {
         PulsarModule::new(
             MODULE_NAME,
             Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            true,
             fs_monitor_task,
         )
     }

--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -9,6 +9,7 @@ pub fn module() -> PulsarModule {
     PulsarModule::new(
         MODULE_NAME,
         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        true,
         logger_task,
     )
 }

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -194,6 +194,7 @@ pub mod pulsar {
         PulsarModule::new(
             MODULE_NAME,
             Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            true,
             network_monitor_task,
         )
     }

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -93,6 +93,7 @@ pub mod pulsar {
         PulsarModule::new(
             MODULE_NAME,
             Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            true,
             process_monitor_task,
         )
     }

--- a/crates/modules/rules-engine/src/lib.rs
+++ b/crates/modules/rules-engine/src/lib.rs
@@ -18,6 +18,7 @@ pub fn module() -> PulsarModule {
     PulsarModule::new(
         MODULE_NAME,
         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        true,
         rules_engine_task,
     )
 }

--- a/crates/modules/smtp-notifier/README.md
+++ b/crates/modules/smtp-notifier/README.md
@@ -18,13 +18,13 @@ Default configuration:
 
 ```ini
 [smtp-notifier]
-enabled=true
+enabled=false
 port=465
 encryption=tls
 ```
 
-You can disable this module with:
+This module is disabled by default. You can enable it with:
 
 ```sh
-pulsar config --set smtp-notifier.enabled=false
+pulsar config --set smtp-notifier.enabled=true
 ```

--- a/crates/modules/smtp-notifier/src/lib.rs
+++ b/crates/modules/smtp-notifier/src/lib.rs
@@ -22,6 +22,7 @@ pub fn module() -> PulsarModule {
     PulsarModule::new(
         MODULE_NAME,
         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        false,
         smtp_notifier_task,
     )
 }

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -34,7 +34,12 @@ pub struct PulsarModule {
 
 impl PulsarModule {
     /// Constucts a new [`PulsarModule<B: Bus>`].
-    pub fn new<N, F, Fut>(name: N, version: Version, task_start_fn: F) -> Self
+    pub fn new<N, F, Fut>(
+        name: N,
+        version: Version,
+        enabled_by_default: bool,
+        task_start_fn: F,
+    ) -> Self
     where
         N: Into<ModuleName>,
         F: Fn(ModuleContext, ShutdownSignal) -> Fut,
@@ -44,7 +49,10 @@ impl PulsarModule {
     {
         Self {
             name: name.into(),
-            info: ModuleDetails { version },
+            info: ModuleDetails {
+                version,
+                enabled_by_default,
+            },
             task_start_fn: Box::new(move |ctx, shutdown| {
                 let module = task_start_fn(ctx, shutdown);
                 Box::new(module)
@@ -123,6 +131,7 @@ impl TaskLauncher for PulsarModule {
 #[derive(Debug, Clone)]
 pub struct ModuleDetails {
     pub version: Version,
+    pub enabled_by_default: bool,
     // pub author: String,
 }
 

--- a/examples/pulsar-embedded-agent/proxy_module.rs
+++ b/examples/pulsar-embedded-agent/proxy_module.rs
@@ -14,6 +14,7 @@ pub fn module(tx_ctx: oneshot::Sender<ModuleContext>) -> PulsarModule {
     PulsarModule::new(
         MODULE_NAME,
         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        true,
         move |ctx, mut shutdown| {
             let tx_ctx = tx_ctx.clone();
             async move {

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -12,6 +12,7 @@ pub fn module() -> PulsarModule {
     PulsarModule::new(
         MODULE_NAME,
         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+        true,
         module_task,
     )
 }

--- a/src/pulsard/daemon.rs
+++ b/src/pulsard/daemon.rs
@@ -93,7 +93,7 @@ impl PulsarDaemon {
             let config = config.get_watched_module_config(&module_name);
             let is_enabled = config
                 .borrow()
-                .with_default("enabled", true)
+                .with_default("enabled", module_details.enabled_by_default)
                 .unwrap_or(false);
             let module_handle = create_module_manager(
                 bus.clone(),


### PR DESCRIPTION
Before this change, empty config of Pulsar was resulting in all modules being enabled. It's quite inconvenient in case of smtp-notifier, which requires additional configuration in order to work without errors, and desktop-notifier, which isn't meant for servers. Both of these modules are not going to be used by most of people.

This change adds the `enabled_by_default` flag to `ModuleDetails` which has to be defined by every module. For all modules except smtp-notifier, it's set to `true`.