### PR TITLE
chore: Use rustls, remove dependency on OpenSSL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,20 +19,19 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, we need to use rustls
           - target: x86_64-unknown-linux-musl
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features full,rustls-tls,test-suite"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, we need to use rustls
           - target: aarch64-unknown-linux-musl
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features full,rustls-tls,test-suite"
 
-          # Dependencies of `xtask` might fail to build on riscv64.
           - target: riscv64gc-unknown-linux-gnu
-            args: "--features full --exclude xtask"
+            args: "--features full"
 
     steps:
       - name: Code checkout

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -52,16 +52,16 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, we need to use rustls
           - target: x86_64-unknown-linux-musl
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features full,rustls-tls,test-suite"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, we need to use rustls
           - target: aarch64-unknown-linux-musl
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features full,rustls-tls,test-suite"
 
           # Dependencies of `xtask` might fail to build on riscv64.
           - target: riscv64gc-unknown-linux-gnu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,25 +53,25 @@ jobs:
       matrix:
         platform:
           - target: x86_64-unknown-linux-gnu
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features smtp-notifier/rustls-tls"
             docker:
               base-image: debian:bookworm
               platform: linux/amd64
 
           - target: x86_64-unknown-linux-musl
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features smtp-notifier/rustls-tls"
 
           - target: aarch64-unknown-linux-gnu
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features smtp-notifier/rustls-tls"
             docker:
               base-image: debian:bookworm
               platform: linux/arm64
           
           - target: aarch64-unknown-linux-musl
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features smtp-notifier/rustls-tls"
 
           - target: riscv64gc-unknown-linux-gnu
-            args: "--features full --features openssl-vendored"
+            args: "--no-default-features --features smtp-notifier/rustls-tls"
             docker:
               base-image: debian:sid
               platform: linux/riscv64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,13 +10,14 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -212,7 +213,7 @@ source = "git+https://github.com/aya-rs/aya?rev=33b2e45ad313f7468a7d11667f13d9c3
 dependencies = [
  "bytes",
  "core-error",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "log",
  "object",
  "thiserror",
@@ -223,6 +224,26 @@ name = "base64"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+
+[[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.33",
+]
 
 [[package]]
 name = "bit-set"
@@ -258,6 +279,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "boring"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fed6dc629997e8c3c4d1dbd59cf748512b9b0e0fbc509cf9b0e2edca9d24d1a"
+dependencies = [
+ "bitflags 2.4.0",
+ "boring-sys",
+ "foreign-types 0.5.0",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "boring-sys"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91102749c3c99028f344c3bce1dc54b1aac49d52d03c60c75996f81ebdeaa41c"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -341,6 +387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +426,27 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.3",
+ "stacker",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -414,6 +490,15 @@ name = "clap_lex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -697,12 +782,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "file-system-monitor"
@@ -734,7 +816,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -744,12 +847,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -863,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -914,11 +1039,11 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "allocator-api2",
 ]
 
@@ -1006,7 +1131,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1065,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1075,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1091,15 +1216,6 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1192,6 +1308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leon"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,34 +1325,52 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.10.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bd09637ae3ec7bd605b8e135e757980b3968430ff2b1a4a94fb7769e50166d"
+checksum = "a48c2e9831b370bc2d7233c2620298c45f3a158ed6b4b8d7416b2ada5a268fd8"
 dependencies = [
  "async-trait",
  "base64",
+ "boring",
+ "chumsky",
  "email-encoding",
  "email_address",
  "fastrand",
  "futures-io",
  "futures-util",
  "httpdate",
- "idna 0.3.0",
+ "idna 0.5.0",
  "mime",
  "native-tls",
  "nom",
  "once_cell",
  "quoted_printable",
- "socket2",
+ "rustls",
+ "rustls-pemfile",
+ "socket2 0.5.5",
  "tokio",
+ "tokio-boring",
  "tokio-native-tls",
+ "tokio-rustls",
+ "url",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libtest-mimic"
@@ -1254,6 +1394,12 @@ name = "linux-raw-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -1461,13 +1607,13 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -1492,23 +1638,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.1.3+3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1545,6 +1681,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1660,6 +1802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "pulsar"
 version = "0.6.0"
 dependencies = [
@@ -1721,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "quoted_printable"
-version = "0.4.8"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
+checksum = "79ec282e887b434b68c18fe5c121d38e72a5cf35119b59e54ec5b992ea9c8eb0"
 
 [[package]]
 name = "rand"
@@ -1766,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1860,17 +2011,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1901,6 +2051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,10 +2085,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.7"
+name = "rustix"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno 0.3.1",
+ "libc",
+ "linux-raw-sys 0.4.12",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
  "ring",
@@ -1951,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
@@ -1988,9 +2157,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -2105,6 +2274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,7 +2350,6 @@ dependencies = [
  "gethostname",
  "leon",
  "lettre",
- "openssl",
  "pulsar-core",
  "rand",
  "tokio",
@@ -2192,10 +2366,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.5.2"
+name = "socket2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2306,15 +2503,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
- "rustix 0.37.3",
- "windows-sys 0.45.0",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.25",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2421,9 +2618,21 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.7",
  "tokio-macros",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-boring"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806b3972e90cd4633771ba91ec25f312a97192010fe4470061700f289524ae57"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "once_cell",
+ "tokio",
 ]
 
 [[package]]
@@ -2654,9 +2863,9 @@ checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3054,4 +3263,24 @@ dependencies = [
  "signal-hook",
  "uuid",
  "xshell",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,25 @@ semver = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["full"]
+default = [
+    "full",
+    # NOTE(vadorovsky): Explicitly enable default features of our internal
+    # dependencies. See the note below for an explanation why is it done.
+    "bpf-common/default",
+    "smtp-notifier/default"
+]
+test-suite = [
+    "bpf-common/test-suite",
+    "file-system-monitor/test-suite",
+    "network-monitor/test-suite",
+    "process-monitor/test-suite",
+    "pulsar-core/test-suite"
+]
+
+# Pulsar modules
 full = ["core", "extra"]
 core = ["logger", "process-monitor", "network-monitor", "file-system-monitor"]
 extra = ["rules-engine", "desktop-notifier", "smtp-notifier"]
-openssl-vendored = ["smtp-notifier?/openssl-vendored"]
 
 [workspace]
 members = [
@@ -72,20 +86,35 @@ edition = "2021"
 repository = "https://github.com/Exein-io/pulsar"
 
 [workspace.dependencies]
+# NOTE(vadorovsky): We define our internal dependencies with
+# `default-features = false` in order to be able to pick features from the main
+# crate (`pulsar`).
+#
+# Without doing so, default features of internal subcrates are being pulled in
+# even when pulsar is being built with:
+#
+# ```
+# cargo build --no-default-features
+# ```
+#
+# Which takes away the freedom of disabling default features.
+
 # Crates
-bpf-builder = { path = "crates/bpf-builder" }
-bpf-common = { path = "crates/bpf-common", features = ["test-utils", "test-suite"] }
-bpf-filtering = { path = "crates/bpf-filtering", features = ["test-suite"] }
-engine-api = { path = "crates/engine-api" }
-pulsar-core = { path = "crates/pulsar-core" }
+bpf-builder = { path = "crates/bpf-builder", default-features = false }
+bpf-common = { path = "crates/bpf-common", default-features = false }
+bpf-filtering = { path = "crates/bpf-filtering", default-features = false }
+engine-api = { path = "crates/engine-api", default-features = false }
+pulsar-core = { path = "crates/pulsar-core", default-features = false }
+validatron = { path = "crates/validatron", default-features = false }
 # Modules
-desktop-notifier = { path = "crates/modules/desktop-notifier" }
-file-system-monitor = { path = "crates/modules/file-system-monitor", features = ["test-suite"] }
+desktop-notifier = { path = "crates/modules/desktop-notifier", default-features = false }
+file-system-monitor = { path = "crates/modules/file-system-monitor", default-features = false }
 logger = { path = "crates/modules/logger" }
-network-monitor = { path = "crates/modules/network-monitor", features = ["test-suite"] }
-process-monitor = { path = "crates/modules/process-monitor", features = ["test-suite"] }
-rules-engine = { path = "crates/modules/rules-engine" }
-smtp-notifier = { path = "crates/modules/smtp-notifier" }
+network-monitor = { path = "crates/modules/network-monitor", default-features = false }
+process-monitor = { path = "crates/modules/process-monitor", default-features = false }
+rules-engine = { path = "crates/modules/rules-engine", default-features = false }
+smtp-notifier = { path = "crates/modules/smtp-notifier", default-features = false }
+
 # External
 anyhow = "1"
 aya = { git = "https://github.com/aya-rs/aya", rev = "33b2e45ad313f7468a7d11667f13d9c365e2a263", features = ["async_tokio"] }
@@ -108,13 +137,12 @@ lalrpop = "0.19.9"
 lalrpop-util = { version="0.19.9", features=["lexer"] }
 lazy_static = "1.4"
 leon = "2.0.1"
-lettre = { version = "0.10.4", default-features = false, features = ["smtp-transport", "tokio1-native-tls", "tokio1", "builder"] }
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder"] }
 libc = "0.2"
 libtest-mimic =  "0.6.0"
 log = "0.4"
 nix = { version = "0.26.2", features = ["fs"] }
 num_cpus = "1.16"
-openssl = { version = "0.10.57" }
 proc-macro2 = "1.0"
 procfs = { version = "0.14.2", default-features = false }
 quote = "1.0"
@@ -136,7 +164,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-fd = "0.3.0"
 tokio-tungstenite = "0.20.1"
 uuid = { version = "1.4", features = ["v4"] }
-validatron = { path = "crates/validatron" }
 validatron-derive = { path = "crates/validatron/derive" }
 which = { version = "4.2.5" }
 xshell = "0.2.2"

--- a/crates/bpf-common/Cargo.toml
+++ b/crates/bpf-common/Cargo.toml
@@ -7,8 +7,7 @@ repository.workspace = true
 
 [features]
 default = []
-test-suite = ["test-utils"]
-test-utils = [
+test-suite = [
   "which",
   "cgroups-rs",
   "rand"

--- a/crates/bpf-common/ProbeTutorial.md
+++ b/crates/bpf-common/ProbeTutorial.md
@@ -36,7 +36,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-test-suite = ["bpf-common/test-utils"]
+test-suite = ["bpf-common/test-suite"]
 
 [dependencies]
 bpf-common = { path = "../../bpf-common" }

--- a/crates/bpf-common/src/lib.rs
+++ b/crates/bpf-common/src/lib.rs
@@ -1,8 +1,8 @@
 mod bpf_sender;
 pub mod program;
-#[cfg(feature = "test-utils")]
+#[cfg(feature = "test-suite")]
 pub mod test_runner;
-#[cfg(feature = "test-utils")]
+#[cfg(feature = "test-suite")]
 pub mod test_utils;
 
 #[cfg(debug_assertions)]

--- a/crates/bpf-common/src/parsing/buffer_index.rs
+++ b/crates/bpf-common/src/parsing/buffer_index.rs
@@ -75,7 +75,7 @@ pub enum IndexError {
     },
 }
 
-#[cfg(feature = "test-utils")]
+#[cfg(feature = "test-suite")]
 mod test_utils {
     use super::*;
     use crate::test_runner::ComparableField;

--- a/crates/bpf-filtering/Cargo.toml
+++ b/crates/bpf-filtering/Cargo.toml
@@ -6,21 +6,30 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
-default = []
+# NOTE(vadorovsky): Explicitly enable default features of our internal
+# dependencies. See the note in the main Cargo.toml for an explanation
+# why is it done.
+default = [
+  "bpf-common/default",
+  "pulsar-core/default"
+]
 test-suite = [
-  "bpf-common/test-utils",
+  "bpf-common/test-suite",
   "which",
   "cgroups-rs",
 ]
 
 [dependencies]
+# Internal
+bpf-common = { workspace = true }
+pulsar-core = { workspace = true }
+
+# External
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 log = { workspace = true }
 anyhow = { workspace = true }
 nix = { workspace = true, features = ["fs"] }
-bpf-common = { workspace = true }
-pulsar-core = { workspace = true }
 regex = { workspace = true }
 which = { workspace = true, optional = true }
 cgroups-rs = { workspace = true, optional = true }

--- a/crates/modules/file-system-monitor/Cargo.toml
+++ b/crates/modules/file-system-monitor/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
-test-suite = ["bpf-common/test-utils"]
+test-suite = [
+  "bpf-common/test-suite",
+  "pulsar-core/test-suite"
+]
 
 [dependencies]
 bpf-common = { workspace = true }

--- a/crates/modules/network-monitor/Cargo.toml
+++ b/crates/modules/network-monitor/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
-test-suite = ["bpf-common/test-utils"]
+test-suite = ["bpf-common/test-suite"]
 
 [dependencies]
 bpf-common = { workspace = true }

--- a/crates/modules/process-monitor/Cargo.toml
+++ b/crates/modules/process-monitor/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
-test-suite = [ "bpf-common/test-utils" ]
+test-suite = [ "bpf-common/test-suite" ]
 
 [dependencies]
 bpf-common = { workspace = true }

--- a/crates/modules/smtp-notifier/Cargo.toml
+++ b/crates/modules/smtp-notifier/Cargo.toml
@@ -10,17 +10,16 @@ pulsar-core = { workspace = true }
 
 tokio = { workspace = true, features = ["full"] }
 anyhow = { workspace = true }
-lettre = { workspace = true, features = [
-    "smtp-transport",
-    "tokio1-native-tls",
-    "tokio1",
-    "builder",
-] }
-openssl = { workspace = true }
+lettre = { workspace = true }
 leon = { workspace = true }
 gethostname = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
 
 [features]
-openssl-vendored = ["openssl/vendored"]
+default = ["native-tls"]
+
+# TLS
+boring-tls = ["lettre/tokio1-boring-tls"]
+native-tls = ["lettre/tokio1-native-tls"]
+rustls-tls = ["lettre/tokio1-rustls-tls"]

--- a/crates/pulsar-core/Cargo.toml
+++ b/crates/pulsar-core/Cargo.toml
@@ -5,9 +5,19 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[features]
+default = [
+  "bpf-common/default"
+]
+test-suite = [
+  "bpf-common/test-suite"
+]
+
 [dependencies]
+# Internal
 bpf-common = { path = "../bpf-common" }
 validatron = { path = "../validatron" }
+
 serde = { workspace = true, features = ["derive"] }
 toml_edit = { workspace = true, features = ["easy"] }
 tokio = { workspace = true, features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use std::env;
 use anyhow::Result;
 use std::sync::OnceLock;
 
-pub use pulsar_core::pdk::TaskLauncher;
+pub use pulsar_core::pdk::{PulsarModule, TaskLauncher};
 
 use cli::PulsarExecOpts;
 
@@ -98,7 +98,7 @@ pub fn modules() -> Vec<Box<dyn TaskLauncher>> {
         smtp_notifier::module(),
     ]
     .into_iter()
-    .map(|x| Box::new(x) as Box<dyn TaskLauncher>)
+    .map(|x: PulsarModule| Box::new(x) as Box<dyn TaskLauncher>)
     .collect()
 }
 

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -6,11 +6,14 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-bpf-common = { workspace = true }
-bpf-filtering = { workspace = true }
-file-system-monitor = { workspace = true }
-network-monitor = { workspace = true }
-process-monitor = { workspace = true }
+# Internal
+bpf-common = { workspace = true, features = ["test-suite"] }
+bpf-filtering = { workspace = true, features = ["test-suite"] }
+file-system-monitor = { workspace = true, features = ["test-suite"] }
+network-monitor = { workspace = true, features = ["test-suite"] }
+process-monitor = { workspace = true, features = ["test-suite"] }
+
+# External
 libtest-mimic =  { workspace = true }
 tokio = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
ring 0.17 supports RISC-V, so building Pulsar with rustls instead of OpenSSL is possible.

Choice of the TLS library is exposed by the following features in the `smtp-notifier` crate:

* `native-tls` - uses the native TLS library in the system, usually OpenSSL. Enabled by default.
* `boring-tls` - uses BoringSSL. Disabled by default.
* `rustls-tls` - uses rustls. Disabled by default.

When building Pulsar with Cargo, the native TLS is going to be used.

However, for binary builds for Github releases, rustls is being used, since it's always statically built and doesn't require any runtime dependencies from the users.