### PR TITLE
rule-engine: support methods and unary expressions in rules dsl

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY ./target/${ARCH}/release/pulsar-exec /usr/sbin/pulsar-exec
 
 COPY .github/docker/pulsar.ini /var/lib/pulsar/pulsar.ini
 
-COPY ./rules/basic-rules.yaml /var/lib/pulsar/rules/basic-rules.yaml
+COPY ./rules/ /var/lib/pulsar/rules/
 
 ENTRYPOINT [ "pulsar-exec" ]
 

--- a/.github/docker/Dockerfile.dockerignore
+++ b/.github/docker/Dockerfile.dockerignore
@@ -5,3 +5,4 @@
 !**/pulsar-exec
 !**/pulsar.ini
 !**/basic-rules.yaml
+!**/container-rules.yaml

--- a/crates/bpf-common/src/parsing/mountinfo.rs
+++ b/crates/bpf-common/src/parsing/mountinfo.rs
@@ -28,7 +28,7 @@ pub enum MountinfoError {
 /// [the kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/proc.txt).
 /// To sum it up, each line contains the following fields:
 ///
-/// ```ignore
+/// ```text
 /// 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
 /// (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
 /// ```

--- a/crates/modules/rules-engine/src/dsl.lalrpop
+++ b/crates/modules/rules-engine/src/dsl.lalrpop
@@ -1,4 +1,4 @@
-use validatron::{Operator, RelationalOperator, StringOperator, MultiOperator, Match, Field, Condition};
+use validatron::{Operator, RelationalOperator, StringOperator, MultiOperator, RValue, Field, Identifier, Condition};
 use lalrpop_util::ParseError;
 
 use super::{DslError};
@@ -12,28 +12,28 @@ pub Condition: Condition = {
 }
 
 SignedCondition: Condition = {
-    "NOT" <b:BaseCondition> => Condition::Not{inner: Box::new(b)},
-    BaseCondition
+    "NOT" <b:BinaryCondition> => Condition::Not{inner: Box::new(b)},
+    BinaryCondition
 }
 
-BaseCondition: Condition = {
-    <f: FieldPath> <op: Operator> <value: Value> => Condition::Base {
-        field_path: f,
+BinaryCondition: Condition = {
+    <f: FieldPath> <op: Operator> <value: Value> => Condition::Binary {
+        l: f,
         op,
-        value: Match::Value(value)
+        r: RValue::Value(value)
     },
-    <f: FieldPath> <op: Operator> <value: FieldPath> => Condition::Base {
-        field_path: f,
+    <f: FieldPath> <op: Operator> <value: FieldPath> => Condition::Binary {
+        l: f,
         op,
-        value: Match::Field(value)
+        r: RValue::Identifier(value)
     },
     <f: FieldPath> "IN" <list: ValueList> =>? {
         let mut iterator = list.into_iter();
 
-        let first = Condition::Base {
-            field_path: f.clone(),
+        let first = Condition::Binary {
+            l: f.clone(),
             op: Operator::Relational(RelationalOperator::Equals),
-            value: iterator.next().map(|x| Match::Value(x)).ok_or(ParseError::User {
+            r: iterator.next().map(|x| RValue::Value(x)).ok_or(ParseError::User {
                 error: DslError::EmptyList
             })?
         };
@@ -41,10 +41,10 @@ BaseCondition: Condition = {
         let ret_val = iterator.fold(first, |acc, x| {
             Condition::Or {
                 l: Box::new(acc),
-                r: Box::new(Condition::Base {
-                    field_path: f.clone(),
+                r: Box::new(Condition::Binary {
+                    l: f.clone(),
                     op: Operator::Relational(RelationalOperator::Equals),
-                    value: Match::Value(x)
+                    r: RValue::Value(x)
                 })
             }
         });
@@ -88,7 +88,7 @@ Operator: Operator = {
     "CONTAINS" => Operator::Multi(MultiOperator::Contains),
 }
 
-FieldPath: Vec<Field> = {
+FieldPath: Vec<Identifier> = {
     <Dot<Ident>> => {
         let mut payload_subpath = false;
         <>.into_iter().enumerate().map(|(index,value)| {
@@ -96,9 +96,9 @@ FieldPath: Vec<Field> = {
                 payload_subpath = true;
             }
             if index == 1 && payload_subpath {
-                Field::Adt{variant_name: variant.to_string(), field_name: value}
+                Identifier::Field(Field::Adt{variant_name: variant.to_string(), field_name: value})
             } else {
-               Field::Simple { field_name: value }
+                Identifier::Field(Field::Simple { field_name: value })
             }  
         }).collect()
     }

--- a/crates/modules/rules-engine/src/dsl.lalrpop
+++ b/crates/modules/rules-engine/src/dsl.lalrpop
@@ -1,7 +1,7 @@
-use validatron::{Operator, RelationalOperator, StringOperator, MultiOperator, RValue, Field, Identifier, Condition};
+use validatron::{Operator, RelationalOperator, StringOperator, MultiOperator, RValue, Field, Identifier, Condition, AdtField, SimpleField, MethodCall};
 use lalrpop_util::ParseError;
 
-use super::{DslError};
+use super::{DslError, IndentValue};
 
 grammar(variant: &str);
 
@@ -51,6 +51,7 @@ BinaryCondition: Condition = {
     
         Ok(ret_val)
     },
+    <f: FieldPath> => Condition::Unary(f),
     "(" <Condition> ")",
 }
 
@@ -89,33 +90,63 @@ Operator: Operator = {
 }
 
 FieldPath: Vec<Identifier> = {
-    <Dot<Ident>> => {
+    <Dot<Ident>> =>? {
         let mut payload_subpath = false;
-        <>.into_iter().enumerate().map(|(index,value)| {
-            if index == 0 && value == "payload" {
-                payload_subpath = true;
+
+        let mut v = Vec::new();
+        v.reserve(<>.len());
+
+        let mut dotted_idents = <>.into_iter().enumerate();
+
+        while let Some((index, value)) = dotted_idents.next() {
+            match value {
+                IndentValue::MethodCall(mc) => {
+                    if index == 0 {
+                        return Err(ParseError::User {
+                            error: DslError::FunctionCall
+                        })
+                    }
+
+                    if dotted_idents.len() == 0 {
+                        v.push(Identifier::MethodCall(mc));
+                    } else {
+                        return Err(ParseError::User {
+                            error: DslError::MethodCallNotFinal
+                        })
+                    }
+                }
+                IndentValue::SimpleField(SimpleField(value)) => {
+                    if index == 0 && value == "payload" {
+                        payload_subpath = true;
+                    }
+
+                    let identifier = if index == 1 && payload_subpath {
+                        Identifier::Field(Field::Adt(AdtField { variant_name: variant.to_string(), field_name: value } ))
+                    } else {
+                        Identifier::Field(Field::Simple(SimpleField(value)))
+                    }; 
+
+                    v.push(identifier);
+                }
             }
-            if index == 1 && payload_subpath {
-                Identifier::Field(Field::Adt{variant_name: variant.to_string(), field_name: value})
-            } else {
-                Identifier::Field(Field::Simple { field_name: value })
-            }  
-        }).collect()
+        }
+
+        Ok(v)
     }
 }
 
 Dot<T>: Vec<T> = {
-    <mut v:(<T> ".")*> <e:T?> => match e {
-        None => v,
-        Some(e) => {
-            v.push(e);
-            v
-        }
+    <v:T> <mut e:("." <T>)*> => if e.is_empty() {
+        vec![v]
+    } else {
+        e.insert(0, v);
+        e
     }
 }
 
-Ident: String = {
-    <s: r"[a-zA-Z]+\w*"> => <>.to_string()
+Ident: IndentValue = {
+    <s: r"[a-zA-Z]+\w*"> => IndentValue::SimpleField(SimpleField(<>.to_string())),
+    <s: r"[a-zA-Z]+\w*">"()" => IndentValue::MethodCall(MethodCall{ name: <>.to_string() })
 }
 
 extern {

--- a/crates/modules/rules-engine/src/dsl.lalrpop
+++ b/crates/modules/rules-engine/src/dsl.lalrpop
@@ -1,7 +1,7 @@
 use validatron::{Operator, RelationalOperator, StringOperator, MultiOperator, RValue, Field, Identifier, Condition, AdtField, SimpleField, MethodCall};
 use lalrpop_util::ParseError;
 
-use super::{DslError, IndentValue};
+use super::{DslError, OptCheck};
 
 grammar(variant: &str);
 
@@ -12,11 +12,11 @@ pub Condition: Condition = {
 }
 
 SignedCondition: Condition = {
-    "NOT" <b:BinaryCondition> => Condition::Not{inner: Box::new(b)},
-    BinaryCondition
+    "NOT" <b:SimpleCondition> => Condition::Not{inner: Box::new(b)},
+    SimpleCondition
 }
 
-BinaryCondition: Condition = {
+SimpleCondition: Condition = {
     <f: FieldPath> <op: Operator> <value: Value> => Condition::Binary {
         l: f,
         op,
@@ -90,7 +90,7 @@ Operator: Operator = {
 }
 
 FieldPath: Vec<Identifier> = {
-    <Dot<Ident>> =>? {
+    <IdentSeq> =>? {
         let mut payload_subpath = false;
 
         let mut v = Vec::new();
@@ -100,7 +100,7 @@ FieldPath: Vec<Identifier> = {
 
         while let Some((index, value)) = dotted_idents.next() {
             match value {
-                IndentValue::MethodCall(mc) => {
+                Identifier::MethodCall(mc) => {
                     if index == 0 {
                         return Err(ParseError::User {
                             error: DslError::FunctionCall
@@ -115,7 +115,7 @@ FieldPath: Vec<Identifier> = {
                         })
                     }
                 }
-                IndentValue::SimpleField(SimpleField(value)) => {
+                Identifier::Field(Field::Simple(SimpleField(value))) => {
                     if index == 0 && value == "payload" {
                         payload_subpath = true;
                     }
@@ -128,6 +128,15 @@ FieldPath: Vec<Identifier> = {
 
                     v.push(identifier);
                 }
+                Identifier::Field(Field::Adt(field)) => {
+                    if index == 0 {
+                        return Err(ParseError::User {
+                            error: DslError::AdtFirstField
+                        })
+                    }                    
+
+                    v.push(Identifier::Field(Field::Adt(field)));
+                }
             }
         }
 
@@ -135,18 +144,34 @@ FieldPath: Vec<Identifier> = {
     }
 }
 
-Dot<T>: Vec<T> = {
-    <v:T> <mut e:("." <T>)*> => if e.is_empty() {
-        vec![v]
-    } else {
-        e.insert(0, v);
-        e
+IdentSeq: Vec<Identifier> = {
+    <v:(<Ident> <OptCheck?> ".")*> <e:Ident> => {
+        let mut res = Vec::new();
+
+        for (ident, opt_check) in v.into_iter() {
+            res.push(ident);
+
+            if opt_check.is_some() {
+                 res.push(Identifier::Field(Field::Adt(AdtField {
+                    variant_name: "Some".to_string(),
+                    field_name: "0".to_string()
+              })));
+            }
+        }
+
+        res.push(e);
+
+        res
     }
 }
 
-Ident: IndentValue = {
-    <s: r"[a-zA-Z]+\w*"> => IndentValue::SimpleField(SimpleField(<>.to_string())),
-    <s: r"[a-zA-Z]+\w*">"()" => IndentValue::MethodCall(MethodCall{ name: <>.to_string() })
+OptCheck: OptCheck = {
+    "?" => OptCheck
+}
+
+Ident: Identifier = {
+    r"[a-zA-Z]+\w*" => Identifier::Field(Field::Simple(SimpleField(<>.to_string()))),
+    <r"[a-zA-Z]+\w*">"()" => Identifier::MethodCall(MethodCall{ name: <>.to_string() })
 }
 
 extern {

--- a/crates/modules/rules-engine/src/dsl.rs
+++ b/crates/modules/rules-engine/src/dsl.rs
@@ -11,7 +11,9 @@ lalrpop_mod!(#[allow(clippy::all)] pub dsl); // syntesized by LALRPOP
 
 #[cfg(test)]
 mod tests {
-    use validatron::{Condition, Field, Match, Operator, RelationalOperator, StringOperator};
+    use validatron::{
+        Condition, Field, Identifier, Operator, RValue, RelationalOperator, StringOperator,
+    };
 
     use super::*;
 
@@ -20,12 +22,12 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"a == 3"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![Identifier::Field(Field::Simple {
                 field_name: "a".to_string(),
-            }],
+            })],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("3".to_string()),
+            r: RValue::Value("3".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -35,17 +37,17 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"header.pid == 3"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![
-                Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![
+                Identifier::Field(Field::Simple {
                     field_name: "header".to_string(),
-                },
-                Field::Simple {
+                }),
+                Identifier::Field(Field::Simple {
                     field_name: "pid".to_string(),
-                },
+                }),
             ],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("3".to_string()),
+            r: RValue::Value("3".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -61,17 +63,17 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"header.pid == 3"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![
-                Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![
+                Identifier::Field(Field::Simple {
                     field_name: "header".to_string(),
-                },
-                Field::Simple {
+                }),
+                Identifier::Field(Field::Simple {
                     field_name: "pid".to_string(),
-                },
+                }),
             ],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("3".to_string()),
+            r: RValue::Value("3".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -81,27 +83,27 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"header == 3"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![Identifier::Field(Field::Simple {
                 field_name: "header".to_string(),
-            }],
+            })],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("3".to_string()),
+            r: RValue::Value("3".to_string()),
         };
         assert_eq!(parsed, expected);
     }
 
     #[test]
-    fn simple_field_path() {
+    fn simple_l() {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"filename == "/etc/passwd""#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![Identifier::Field(Field::Simple {
                 field_name: "filename".to_string(),
-            }],
+            })],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("/etc/passwd".to_string()),
+            r: RValue::Value("/etc/passwd".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -111,12 +113,12 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"image == "systemd""#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![Identifier::Field(Field::Simple {
                 field_name: "image".to_string(),
-            }],
+            })],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("systemd".to_string()),
+            r: RValue::Value("systemd".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -126,12 +128,12 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"image STARTS_WITH "systemd""#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![Identifier::Field(Field::Simple {
                 field_name: "image".to_string(),
-            }],
+            })],
             op: Operator::String(StringOperator::StartsWith),
-            value: Match::Value("systemd".to_string()),
+            r: RValue::Value("systemd".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -141,20 +143,20 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"struct.field.nested == 3"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![
-                Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![
+                Identifier::Field(Field::Simple {
                     field_name: "struct".to_string(),
-                },
-                Field::Simple {
+                }),
+                Identifier::Field(Field::Simple {
                     field_name: "field".to_string(),
-                },
-                Field::Simple {
+                }),
+                Identifier::Field(Field::Simple {
                     field_name: "nested".to_string(),
-                },
+                }),
             ],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("3".to_string()),
+            r: RValue::Value("3".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -165,17 +167,17 @@ mod tests {
             .parse("Exec", r#"NOT(header.image != "/usr/bin/sshd")"#)
             .unwrap();
         let expected = Condition::Not {
-            inner: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            inner: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "image".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::NotEquals),
-                value: Match::Value("/usr/bin/sshd".to_string()),
+                r: RValue::Value("/usr/bin/sshd".to_string()),
             }),
         };
         assert_eq!(parsed, expected);
@@ -187,17 +189,17 @@ mod tests {
             .parse("Exec", r#"NOT (header.image != "/usr/bin/sshd")"#)
             .unwrap();
         let expected = Condition::Not {
-            inner: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            inner: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "image".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::NotEquals),
-                value: Match::Value("/usr/bin/sshd".to_string()),
+                r: RValue::Value("/usr/bin/sshd".to_string()),
             }),
         };
         assert_eq!(parsed, expected);
@@ -212,30 +214,30 @@ mod tests {
             )
             .unwrap();
         let expected = Condition::And {
-            l: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            l: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "image".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::NotEquals),
-                value: Match::Value("/usr/bin/sshd".to_string()),
+                r: RValue::Value("/usr/bin/sshd".to_string()),
             }),
-            r: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            r: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "payload".to_string(),
-                    },
-                    Field::Adt {
+                    }),
+                    Identifier::Field(Field::Adt {
                         variant_name: "Exec".to_string(),
                         field_name: "filename".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("/etc/shadow".to_string()),
+                r: RValue::Value("/etc/shadow".to_string()),
             }),
         };
         assert_eq!(parsed, expected);
@@ -250,30 +252,30 @@ mod tests {
             )
             .unwrap();
         let expected = Condition::Or {
-            l: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            l: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "image".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::NotEquals),
-                value: Match::Value("/usr/bin/sshd".to_string()),
+                r: RValue::Value("/usr/bin/sshd".to_string()),
             }),
-            r: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            r: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "payload".to_string(),
-                    },
-                    Field::Adt {
+                    }),
+                    Identifier::Field(Field::Adt {
                         variant_name: "FileOpen".to_string(),
                         field_name: "filename".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("/etc/shadow".to_string()),
+                r: RValue::Value("/etc/shadow".to_string()),
             }),
         };
         assert_eq!(parsed, expected);
@@ -285,44 +287,44 @@ mod tests {
             .parse("Exec",r#"header.image == "/usr/bin/sshd" OR NOT(header.image == "/usr/bin/cat" AND payload.filename == "/etc/passwd")"#)
             .unwrap();
         let expected = Condition::Or {
-            l: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            l: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "image".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("/usr/bin/sshd".to_string()),
+                r: RValue::Value("/usr/bin/sshd".to_string()),
             }),
             r: Box::new(Condition::Not {
                 inner: Box::new(Condition::And {
-                    l: Box::new(Condition::Base {
-                        field_path: vec![
-                            Field::Simple {
+                    l: Box::new(Condition::Binary {
+                        l: vec![
+                            Identifier::Field(Field::Simple {
                                 field_name: "header".to_string(),
-                            },
-                            Field::Simple {
+                            }),
+                            Identifier::Field(Field::Simple {
                                 field_name: "image".to_string(),
-                            },
+                            }),
                         ],
                         op: Operator::Relational(RelationalOperator::Equals),
-                        value: Match::Value("/usr/bin/cat".to_string()),
+                        r: RValue::Value("/usr/bin/cat".to_string()),
                     }),
-                    r: Box::new(Condition::Base {
-                        field_path: vec![
-                            Field::Simple {
+                    r: Box::new(Condition::Binary {
+                        l: vec![
+                            Identifier::Field(Field::Simple {
                                 field_name: "payload".to_string(),
-                            },
-                            Field::Adt {
+                            }),
+                            Identifier::Field(Field::Adt {
                                 variant_name: "Exec".to_string(),
                                 field_name: "filename".to_string(),
-                            },
+                            }),
                         ],
                         op: Operator::Relational(RelationalOperator::Equals),
-                        value: Match::Value("/etc/passwd".to_string()),
+                        r: RValue::Value("/etc/passwd".to_string()),
                     }),
                 }),
             }),
@@ -335,17 +337,17 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("Exec", r#"header.image IN ["/usr/bin/cat"]"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![
-                Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![
+                Identifier::Field(Field::Simple {
                     field_name: "header".to_string(),
-                },
-                Field::Simple {
+                }),
+                Identifier::Field(Field::Simple {
                     field_name: "image".to_string(),
-                },
+                }),
             ],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Value("/usr/bin/cat".to_string()),
+            r: RValue::Value("/usr/bin/cat".to_string()),
         };
         assert_eq!(parsed, expected);
     }
@@ -356,29 +358,29 @@ mod tests {
             .parse("Exec", r#"header.pid IN [4,2]"#)
             .unwrap();
         let expected = Condition::Or {
-            l: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            l: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "pid".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("4".to_string()),
+                r: RValue::Value("4".to_string()),
             }),
-            r: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            r: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "pid".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("2".to_string()),
+                r: RValue::Value("2".to_string()),
             }),
         };
         assert_eq!(parsed, expected);
@@ -391,42 +393,42 @@ mod tests {
             .unwrap();
         let expected = Condition::Or {
             l: Box::new(Condition::Or {
-                l: Box::new(Condition::Base {
-                    field_path: vec![
-                        Field::Simple {
+                l: Box::new(Condition::Binary {
+                    l: vec![
+                        Identifier::Field(Field::Simple {
                             field_name: "header".to_string(),
-                        },
-                        Field::Simple {
+                        }),
+                        Identifier::Field(Field::Simple {
                             field_name: "pid".to_string(),
-                        },
+                        }),
                     ],
                     op: Operator::Relational(RelationalOperator::Equals),
-                    value: Match::Value("6".to_string()),
+                    r: RValue::Value("6".to_string()),
                 }),
-                r: Box::new(Condition::Base {
-                    field_path: vec![
-                        Field::Simple {
+                r: Box::new(Condition::Binary {
+                    l: vec![
+                        Identifier::Field(Field::Simple {
                             field_name: "header".to_string(),
-                        },
-                        Field::Simple {
+                        }),
+                        Identifier::Field(Field::Simple {
                             field_name: "pid".to_string(),
-                        },
+                        }),
                     ],
                     op: Operator::Relational(RelationalOperator::Equals),
-                    value: Match::Value("6".to_string()),
+                    r: RValue::Value("6".to_string()),
                 }),
             }),
-            r: Box::new(Condition::Base {
-                field_path: vec![
-                    Field::Simple {
+            r: Box::new(Condition::Binary {
+                l: vec![
+                    Identifier::Field(Field::Simple {
                         field_name: "header".to_string(),
-                    },
-                    Field::Simple {
+                    }),
+                    Identifier::Field(Field::Simple {
                         field_name: "pid".to_string(),
-                    },
+                    }),
                 ],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("6".to_string()),
+                r: RValue::Value("6".to_string()),
             }),
         };
         assert_eq!(parsed, expected);
@@ -443,24 +445,24 @@ mod tests {
         let parsed = dsl::ConditionParser::new()
             .parse("FileDelete", r#"header.image == payload.filename"#)
             .unwrap();
-        let expected = Condition::Base {
-            field_path: vec![
-                Field::Simple {
+        let expected = Condition::Binary {
+            l: vec![
+                Identifier::Field(Field::Simple {
                     field_name: "header".to_string(),
-                },
-                Field::Simple {
+                }),
+                Identifier::Field(Field::Simple {
                     field_name: "image".to_string(),
-                },
+                }),
             ],
             op: Operator::Relational(RelationalOperator::Equals),
-            value: Match::Field(vec![
-                Field::Simple {
+            r: RValue::Identifier(vec![
+                Identifier::Field(Field::Simple {
                     field_name: "payload".to_string(),
-                },
-                Field::Adt {
+                }),
+                Identifier::Field(Field::Adt {
                     variant_name: "FileDelete".to_string(),
                     field_name: "filename".to_string(),
-                },
+                }),
             ]),
         };
         assert_eq!(parsed, expected);

--- a/crates/modules/rules-engine/src/engine.rs
+++ b/crates/modules/rules-engine/src/engine.rs
@@ -188,7 +188,10 @@ impl RuleFile {
 #[cfg(test)]
 mod tests {
     use pulsar_core::event::PayloadDiscriminant;
-    use validatron::{Condition, Field, Identifier, Operator, RValue, RelationalOperator, Rule};
+    use validatron::{
+        AdtField, Condition, Field, Identifier, Operator, RValue, RelationalOperator, Rule,
+        SimpleField,
+    };
 
     use crate::{
         dsl,
@@ -213,13 +216,11 @@ mod tests {
                 name: "Open netcat".to_string(),
                 condition: Condition::Binary {
                     l: vec![
-                        Identifier::Field(Field::Simple {
-                            field_name: "payload".to_string(),
-                        }),
-                        Identifier::Field(Field::Adt {
+                        Identifier::Field(Field::Simple(SimpleField("payload".to_string()))),
+                        Identifier::Field(Field::Adt(AdtField {
                             variant_name: "Exec".to_string(),
                             field_name: "filename".to_string(),
-                        }),
+                        })),
                     ],
                     op: Operator::Relational(RelationalOperator::Equals),
                     r: RValue::Value("/usr/bin/nc".to_string()),

--- a/crates/modules/rules-engine/src/engine.rs
+++ b/crates/modules/rules-engine/src/engine.rs
@@ -188,7 +188,7 @@ impl RuleFile {
 #[cfg(test)]
 mod tests {
     use pulsar_core::event::PayloadDiscriminant;
-    use validatron::{Condition, Field, Match, Operator, RelationalOperator, Rule};
+    use validatron::{Condition, Field, Identifier, Operator, RValue, RelationalOperator, Rule};
 
     use crate::{
         dsl,
@@ -211,18 +211,18 @@ mod tests {
             PayloadDiscriminant::Exec,
             Rule {
                 name: "Open netcat".to_string(),
-                condition: Condition::Base {
-                    field_path: vec![
-                        Field::Simple {
+                condition: Condition::Binary {
+                    l: vec![
+                        Identifier::Field(Field::Simple {
                             field_name: "payload".to_string(),
-                        },
-                        Field::Adt {
+                        }),
+                        Identifier::Field(Field::Adt {
                             variant_name: "Exec".to_string(),
                             field_name: "filename".to_string(),
-                        },
+                        }),
                     ],
                     op: Operator::Relational(RelationalOperator::Equals),
-                    value: Match::Value("/usr/bin/nc".to_string()),
+                    r: RValue::Value("/usr/bin/nc".to_string()),
                 },
             },
         );

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -82,7 +82,6 @@ pub struct Header {
     pub image: String,
     pub pid: i32,
     pub parent_pid: i32,
-    #[validatron(skip)]
     pub container: Option<ContainerInfo>,
     #[validatron(skip)]
     pub threat: Option<Threat>,

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -419,35 +419,37 @@ impl FileFlags {
 
 impl Validatron for FileFlags {
     fn get_class() -> validatron::ValidatronClass {
-        Self::class_builder().primitive(
-            Box::new(|s| {
-                FileFlags::ACC_MODE_FLAGS
-                    .iter()
-                    .chain(FileFlags::OTHER_FLAGS.iter())
-                    .find(|(name, _)| *name == s)
-                    .map(|(_, flag)| Self(*flag))
-                    .ok_or_else(|| ValidatronError::FieldValueParseError(s.to_string()))
-            }),
-            Box::new(|op| match op {
-                Operator::Multi(op) => match op {
-                    validatron::MultiOperator::Contains => Ok(Box::new(|a, b| {
-                        if FileFlags::ACC_MODE_FLAGS
-                            .iter()
-                            .any(|(_, acc_mode_flag)| acc_mode_flag == &b.0)
-                        {
-                            let mode = a.0 & kernel::file::flags::O_ACCMODE;
-                            mode == b.0
-                        } else {
-                            (a.0 & b.0) > 0
-                        }
-                    })),
-                },
-                _ => Err(ValidatronError::OperatorNotAllowedOnType(
-                    op,
-                    "FileFlags".to_string(),
-                )),
-            }),
-        )
+        Self::class_builder()
+            .primitive_class_builder(
+                Box::new(|s| {
+                    FileFlags::ACC_MODE_FLAGS
+                        .iter()
+                        .chain(FileFlags::OTHER_FLAGS.iter())
+                        .find(|(name, _)| *name == s)
+                        .map(|(_, flag)| Self(*flag))
+                        .ok_or_else(|| ValidatronError::FieldValueParseError(s.to_string()))
+                }),
+                Box::new(|op| match op {
+                    Operator::Multi(op) => match op {
+                        validatron::MultiOperator::Contains => Ok(Box::new(|a, b| {
+                            if FileFlags::ACC_MODE_FLAGS
+                                .iter()
+                                .any(|(_, acc_mode_flag)| acc_mode_flag == &b.0)
+                            {
+                                let mode = a.0 & kernel::file::flags::O_ACCMODE;
+                                mode == b.0
+                            } else {
+                                (a.0 & b.0) > 0
+                            }
+                        })),
+                    },
+                    _ => Err(ValidatronError::OperatorNotAllowedOnType(
+                        op,
+                        "FileFlags".to_string(),
+                    )),
+                }),
+            )
+            .build()
     }
 }
 
@@ -499,20 +501,22 @@ impl From<Vec<String>> for Argv {
 
 impl Validatron for Argv {
     fn get_class() -> validatron::ValidatronClass {
-        Self::class_builder().primitive(
-            Box::new(|s| Ok(Argv(vec![s.to_string()]))),
-            Box::new(|op| match op {
-                Operator::Multi(op) => match op {
-                    validatron::MultiOperator::Contains => {
-                        Ok(Box::new(|a, b| b.0.iter().all(|item| a.0.contains(item))))
-                    }
-                },
-                _ => Err(ValidatronError::OperatorNotAllowedOnType(
-                    op,
-                    "Argv".to_string(),
-                )),
-            }),
-        )
+        Self::class_builder()
+            .primitive_class_builder(
+                Box::new(|s| Ok(Argv(vec![s.to_string()]))),
+                Box::new(|op| match op {
+                    Operator::Multi(op) => match op {
+                        validatron::MultiOperator::Contains => {
+                            Ok(Box::new(|a, b| b.0.iter().all(|item| a.0.contains(item))))
+                        }
+                    },
+                    _ => Err(ValidatronError::OperatorNotAllowedOnType(
+                        op,
+                        "Argv".to_string(),
+                    )),
+                }),
+            )
+            .build()
     }
 }
 

--- a/crates/pulsar-core/src/pdk/mod.rs
+++ b/crates/pulsar-core/src/pdk/mod.rs
@@ -34,6 +34,7 @@
 //!     PulsarModule::new(
 //!         "my-module",
 //!         Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+//!         true,
 //!         my_module_task,
 //!     )
 //! }

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -92,24 +92,28 @@ impl fmt::Display for ModuleName {
 
 impl Validatron for ModuleName {
     fn get_class() -> validatron::ValidatronClass {
-        Self::class_builder().primitive(
-            Box::new(|s| Ok(ModuleName(Cow::Owned(s.to_string())))),
-            Box::new(|op| match op {
-                validatron::Operator::String(op) => match op {
-                    validatron::StringOperator::StartsWith => {
-                        Ok(Box::new(|a, b| a.0.as_ref().starts_with(b.0.as_ref())))
+        Self::class_builder()
+            .primitive_class_builder(
+                Box::new(|s| Ok(ModuleName(Cow::Owned(s.to_string())))),
+                Box::new(|op| match op {
+                    validatron::Operator::String(op) => match op {
+                        validatron::StringOperator::StartsWith => {
+                            Ok(Box::new(|a, b| a.0.as_ref().starts_with(b.0.as_ref())))
+                        }
+                        validatron::StringOperator::EndsWith => {
+                            Ok(Box::new(|a, b| a.0.as_ref().ends_with(b.0.as_ref())))
+                        }
+                    },
+                    validatron::Operator::Relational(op) => {
+                        Ok(Box::new(move |a, b| op.apply(a, b)))
                     }
-                    validatron::StringOperator::EndsWith => {
-                        Ok(Box::new(|a, b| a.0.as_ref().ends_with(b.0.as_ref())))
-                    }
-                },
-                validatron::Operator::Relational(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
-                _ => Err(validatron::ValidatronError::OperatorNotAllowedOnType(
-                    op,
-                    "ModuleName".to_string(),
-                )),
-            }),
-        )
+                    _ => Err(validatron::ValidatronError::OperatorNotAllowedOnType(
+                        op,
+                        "ModuleName".to_string(),
+                    )),
+                }),
+            )
+            .build()
     }
 }
 

--- a/crates/validatron/README.md
+++ b/crates/validatron/README.md
@@ -7,17 +7,17 @@ Basically it's a way for check the correctness of rules over types and subsequen
 It check if fields specified in a rules are valid for a given type. Example:
 
 ```rust
-use validatron::validator::get_valid_rule;
+use validatron::validator::{get_valid_rule, Operator, RelationalOperator, Identifier, Field, RValue};
 #[derive(Validatron)]
 struct MyStruct {
     my_value: i32
 }
 let rule = get_valid_rule::<MyStruct>(
-    vec![Field::Simple {
+    vec![Identifier::Field(Field::Simple {
         field_name: "my_value".to_string(),
-    }],
+    })],
     Operator::Relational(RelationalOperator::Equals),
-    Match::Value("42".to_string()),
+    RValue::Value("42".to_string()),
 )
 .unwrap();
 let test = MyStruct { my_value: 42 };
@@ -30,7 +30,7 @@ specific field type (`i32`).
 On top of this it's possible to write complex rules, assembling conditions with logical operators (AND, OR, NOT). Example:
 
 ```rust
-use validatron::{Ruleset, Rule, Validatron, Operator, RelationalOperator, Condition, Match};
+use validatron::{Ruleset, Rule, Validatron, Operator, RelationalOperator, Condition, Identifier, Field, RValue};
 #[derive(Validatron)]
 struct MyStruct {
     my_value: i32,
@@ -39,30 +39,30 @@ let ruleset: Ruleset<MyStruct> = Ruleset::from_rules(vec![
     Rule {
         name: "my_value equal to 3 or 5".to_string(),
         condition: Condition::Or {
-            l: Box::new(Condition::Base {
-                field_path: vec![Field::Simple {
+            l: Box::new(Condition::Binary {
+                l: vec![Identifier::Field(Field::Simple {
                     field_name: "my_value".to_string(),
-                }],
+                })],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("3".to_string()),
+                r: RValue::Value("3".to_string()),
             }),
-            r: Box::new(Condition::Base {
-                field_path: vec![Field::Simple {
+            r: Box::new(Condition::Binary {
+                l: vec![Identifier::Field(Field::Simple {
                     field_name: "my_value".to_string(),
-                }],
+                })],
                 op: Operator::Relational(RelationalOperator::Equals),
-                value: Match::Value("5".to_string()),
+                r: RValue::Value("5".to_string()),
             }),
         },
     },
     Rule {
         name: "my_value greater than 100".to_string(),
-        condition: Condition::Base {
-            field_path: vec![Field::Simple {
+        condition: Condition::Binary {
+            l: vec![Identifier::Field(Field::Simple {
                 field_name: "my_value".to_string(),
-            }],
+            })],
             op: Operator::Relational(RelationalOperator::Greater),
-            value: Match::Value("100".to_string()),
+            r: RValue::Value("100".to_string()),
         },
     },
 ])

--- a/crates/validatron/README.md
+++ b/crates/validatron/README.md
@@ -7,15 +7,15 @@ Basically it's a way for check the correctness of rules over types and subsequen
 It check if fields specified in a rules are valid for a given type. Example:
 
 ```rust
-use validatron::validator::{get_valid_rule, Operator, RelationalOperator, Identifier, Field, RValue};
+use validatron::validator::{get_valid_rule, Operator, RelationalOperator, Identifier, Field, RValue, SimpleField};
 #[derive(Validatron)]
 struct MyStruct {
     my_value: i32
 }
 let rule = get_valid_rule::<MyStruct>(
-    vec![Identifier::Field(Field::Simple {
-        field_name: "my_value".to_string(),
-    })],
+    vec![Identifier::Field(Field::Simple(SimpleField(
+        "my_value".to_string()
+    )))],
     Operator::Relational(RelationalOperator::Equals),
     RValue::Value("42".to_string()),
 )
@@ -30,7 +30,7 @@ specific field type (`i32`).
 On top of this it's possible to write complex rules, assembling conditions with logical operators (AND, OR, NOT). Example:
 
 ```rust
-use validatron::{Ruleset, Rule, Validatron, Operator, RelationalOperator, Condition, Identifier, Field, RValue};
+use validatron::{Ruleset, Rule, Validatron, Operator, RelationalOperator, Condition, Identifier, Field, RValue, SimpleField};
 #[derive(Validatron)]
 struct MyStruct {
     my_value: i32,
@@ -40,16 +40,16 @@ let ruleset: Ruleset<MyStruct> = Ruleset::from_rules(vec![
         name: "my_value equal to 3 or 5".to_string(),
         condition: Condition::Or {
             l: Box::new(Condition::Binary {
-                l: vec![Identifier::Field(Field::Simple {
-                    field_name: "my_value".to_string(),
-                })],
+                l: vec![Identifier::Field(Field::Simple(SimpleField(
+                    "my_value".to_string()
+                )))],
                 op: Operator::Relational(RelationalOperator::Equals),
                 r: RValue::Value("3".to_string()),
             }),
             r: Box::new(Condition::Binary {
-                l: vec![Identifier::Field(Field::Simple {
-                    field_name: "my_value".to_string(),
-                })],
+                l: vec![Identifier::Field(Field::Simple(SimpleField(
+                    "my_value".to_string()
+                )))],
                 op: Operator::Relational(RelationalOperator::Equals),
                 r: RValue::Value("5".to_string()),
             }),
@@ -58,9 +58,9 @@ let ruleset: Ruleset<MyStruct> = Ruleset::from_rules(vec![
     Rule {
         name: "my_value greater than 100".to_string(),
         condition: Condition::Binary {
-            l: vec![Identifier::Field(Field::Simple {
-                field_name: "my_value".to_string(),
-            })],
+            l: vec![Identifier::Field(Field::Simple(SimpleField(
+                "my_value".to_string()
+            )))],
             op: Operator::Relational(RelationalOperator::Greater),
             r: RValue::Value("100".to_string()),
         },

--- a/crates/validatron/examples/struct.rs
+++ b/crates/validatron/examples/struct.rs
@@ -1,7 +1,8 @@
 use std::error::Error;
 
 use validatron::{
-    validator::get_valid_rule, Field, Identifier, Operator, RValue, RelationalOperator, Validatron,
+    validator::get_valid_rule, Field, Identifier, Operator, RValue, RelationalOperator,
+    SimpleField, Validatron,
 };
 
 #[derive(Debug, Clone, Validatron)]
@@ -14,9 +15,9 @@ pub struct MyStruct {
 /// Match the field "a" against the fixed value "111" using the "Equals" operator
 fn fixed_match(test: &MyStruct) -> Result<bool, Box<dyn Error>> {
     let rule = get_valid_rule::<MyStruct>(
-        vec![Identifier::Field(Field::Simple {
-            field_name: "a".to_string(),
-        })],
+        vec![Identifier::Field(Field::Simple(SimpleField(
+            "a".to_string(),
+        )))],
         Operator::Relational(RelationalOperator::Equals),
         RValue::Value("111".to_string()),
     )?;
@@ -27,13 +28,13 @@ fn fixed_match(test: &MyStruct) -> Result<bool, Box<dyn Error>> {
 /// Match the field "a" against the field "b" using the "Greater" operator
 fn dynamic_match(test: &MyStruct) -> Result<bool, Box<dyn Error>> {
     let rule = get_valid_rule::<MyStruct>(
-        vec![Identifier::Field(Field::Simple {
-            field_name: "a".to_string(),
-        })],
+        vec![Identifier::Field(Field::Simple(SimpleField(
+            "a".to_string(),
+        )))],
         Operator::Relational(RelationalOperator::Greater),
-        RValue::Identifier(vec![Identifier::Field(Field::Simple {
-            field_name: "b".to_string(),
-        })]),
+        RValue::Identifier(vec![Identifier::Field(Field::Simple(SimpleField(
+            "b".to_string(),
+        )))]),
     )?;
 
     Ok(rule.is_match(test))

--- a/crates/validatron/examples/struct.rs
+++ b/crates/validatron/examples/struct.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use validatron::{
-    validator::get_valid_rule, Field, Match, Operator, RelationalOperator, Validatron,
+    validator::get_valid_rule, Field, Identifier, Operator, RValue, RelationalOperator, Validatron,
 };
 
 #[derive(Debug, Clone, Validatron)]
@@ -14,11 +14,11 @@ pub struct MyStruct {
 /// Match the field "a" against the fixed value "111" using the "Equals" operator
 fn fixed_match(test: &MyStruct) -> Result<bool, Box<dyn Error>> {
     let rule = get_valid_rule::<MyStruct>(
-        vec![Field::Simple {
+        vec![Identifier::Field(Field::Simple {
             field_name: "a".to_string(),
-        }],
+        })],
         Operator::Relational(RelationalOperator::Equals),
-        Match::Value("111".to_string()),
+        RValue::Value("111".to_string()),
     )?;
 
     Ok(rule.is_match(test))
@@ -27,13 +27,13 @@ fn fixed_match(test: &MyStruct) -> Result<bool, Box<dyn Error>> {
 /// Match the field "a" against the field "b" using the "Greater" operator
 fn dynamic_match(test: &MyStruct) -> Result<bool, Box<dyn Error>> {
     let rule = get_valid_rule::<MyStruct>(
-        vec![Field::Simple {
+        vec![Identifier::Field(Field::Simple {
             field_name: "a".to_string(),
-        }],
+        })],
         Operator::Relational(RelationalOperator::Greater),
-        Match::Field(vec![Field::Simple {
+        RValue::Identifier(vec![Identifier::Field(Field::Simple {
             field_name: "b".to_string(),
-        }]),
+        })]),
     )?;
 
     Ok(rule.is_match(test))

--- a/crates/validatron/src/builtins.rs
+++ b/crates/validatron/src/builtins.rs
@@ -111,6 +111,7 @@ impl<T: Validatron + Send + Sync + 'static> Validatron for Option<T> {
     fn get_class() -> ValidatronClass {
         Self::class_builder()
             .enum_class_builder()
+            .add_variant_field("Some", "0", Box::new(Option::as_ref))
             .add_method0("is_some", Box::new(|c| c.is_some()))
             .build()
     }
@@ -118,7 +119,11 @@ impl<T: Validatron + Send + Sync + 'static> Validatron for Option<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::{validator::get_valid_unary_rule, Identifier, MethodCall};
+    use crate::{
+        validator::{get_valid_rule, get_valid_unary_rule},
+        AdtField, Field, Identifier, MethodCall, Operator, RValue, RelationalOperator, SimpleField,
+        Validatron,
+    };
 
     #[test]
     fn test_option_no_method() {
@@ -151,5 +156,136 @@ mod test {
         let test = None;
 
         assert!(!rule.is_match(&test));
+    }
+
+    #[test]
+    fn test_option_field_success() {
+        struct A {
+            a: i32,
+        }
+
+        impl Validatron for A {
+            fn get_class() -> crate::ValidatronClass {
+                Self::class_builder()
+                    .struct_class_builder()
+                    .add_field("a", Box::new(|t| &t.a))
+                    .build()
+            }
+        }
+
+        let rule = get_valid_rule::<Option<A>>(
+            vec![
+                Identifier::Field(Field::Adt(AdtField {
+                    variant_name: "Some".to_string(),
+                    field_name: "0".to_string(),
+                })),
+                Identifier::Field(Field::Simple(SimpleField("a".to_string()))),
+            ],
+            Operator::Relational(RelationalOperator::Equals),
+            RValue::Value("5".to_string()),
+        )
+        .unwrap();
+
+        let test = Some(A { a: 5 });
+
+        assert!(rule.is_match(&test));
+    }
+
+    #[test]
+    fn test_option_field_fail() {
+        struct A {
+            a: i32,
+        }
+
+        impl Validatron for A {
+            fn get_class() -> crate::ValidatronClass {
+                Self::class_builder()
+                    .struct_class_builder()
+                    .add_field("a", Box::new(|t| &t.a))
+                    .build()
+            }
+        }
+
+        let rule = get_valid_rule::<Option<A>>(
+            vec![
+                Identifier::Field(Field::Adt(AdtField {
+                    variant_name: "Some".to_string(),
+                    field_name: "0".to_string(),
+                })),
+                Identifier::Field(Field::Simple(SimpleField("a".to_string()))),
+            ],
+            Operator::Relational(RelationalOperator::Equals),
+            RValue::Value("5".to_string()),
+        )
+        .unwrap();
+
+        let test = None;
+
+        assert!(!rule.is_match(&test));
+    }
+
+    #[test]
+    fn test_option_field_nested_success() {
+        struct A {
+            b: Option<B>,
+        }
+
+        struct B {
+            c: C,
+        }
+
+        struct C {
+            inner: i32,
+        }
+
+        impl Validatron for A {
+            fn get_class() -> crate::ValidatronClass {
+                Self::class_builder()
+                    .struct_class_builder()
+                    .add_field("b", Box::new(|t| &t.b))
+                    .build()
+            }
+        }
+
+        impl Validatron for B {
+            fn get_class() -> crate::ValidatronClass {
+                Self::class_builder()
+                    .struct_class_builder()
+                    .add_field("c", Box::new(|t| &t.c))
+                    .build()
+            }
+        }
+
+        impl Validatron for C {
+            fn get_class() -> crate::ValidatronClass {
+                Self::class_builder()
+                    .struct_class_builder()
+                    .add_field("inner", Box::new(|t| &t.inner))
+                    .build()
+            }
+        }
+
+        let rule = get_valid_rule::<A>(
+            vec![
+                Identifier::Field(Field::Simple(SimpleField("b".to_string()))),
+                Identifier::Field(Field::Adt(AdtField {
+                    variant_name: "Some".to_string(),
+                    field_name: "0".to_string(),
+                })),
+                Identifier::Field(Field::Simple(SimpleField("c".to_string()))),
+                Identifier::Field(Field::Simple(SimpleField("inner".to_string()))),
+            ],
+            Operator::Relational(RelationalOperator::Equals),
+            RValue::Value("666".to_string()),
+        )
+        .unwrap();
+
+        let test = A {
+            b: Some(B {
+                c: C { inner: 666 },
+            }),
+        };
+
+        assert!(rule.is_match(&test));
     }
 }

--- a/crates/validatron/src/builtins.rs
+++ b/crates/validatron/src/builtins.rs
@@ -11,7 +11,7 @@ macro_rules! impl_numeric {
             $(
                 impl $crate::Validatron for $x {
                     fn get_class() -> ValidatronClass {
-                        Self::class_builder().primitive(
+                        Self::class_builder().primitive_class_builder(
                             Box::new(|s| {
                                 <$x>::from_str(s).map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
                             }),
@@ -22,7 +22,7 @@ macro_rules! impl_numeric {
                                     stringify!($x).to_string(),
                                 )),
                             }),
-                        )
+                        ).build()
                     }
                 }
             )*
@@ -36,66 +36,120 @@ impl_numeric![f32, f64];
 
 impl Validatron for String {
     fn get_class() -> ValidatronClass {
-        Self::class_builder().primitive(
-            Box::new(|s| {
-                String::from_str(s)
-                    .map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
-            }),
-            Box::new(|op| match op {
-                Operator::String(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
-                Operator::Relational(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
-                Operator::Multi(op) => match op {
-                    MultiOperator::Contains => Ok(Box::new(move |a, b| a.contains(b))),
-                },
-            }),
-        )
+        Self::class_builder()
+            .primitive_class_builder(
+                Box::new(|s| {
+                    String::from_str(s)
+                        .map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
+                }),
+                Box::new(|op| match op {
+                    Operator::String(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
+                    Operator::Relational(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
+                    Operator::Multi(op) => match op {
+                        MultiOperator::Contains => Ok(Box::new(move |a, b| a.contains(b))),
+                    },
+                }),
+            )
+            .build()
     }
 }
 
 impl Validatron for bool {
     fn get_class() -> ValidatronClass {
-        Self::class_builder().primitive(
-            Box::new(|s| {
-                bool::from_str(s).map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
-            }),
-            Box::new(|op| match &op {
-                Operator::Relational(rel_op) => match rel_op {
-                    RelationalOperator::Equals => Ok(Box::new(move |a, b| a == b)),
-                    RelationalOperator::NotEquals => Ok(Box::new(move |a, b| a != b)),
+        Self::class_builder()
+            .primitive_class_builder(
+                Box::new(|s| {
+                    bool::from_str(s)
+                        .map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
+                }),
+                Box::new(|op| match &op {
+                    Operator::Relational(rel_op) => match rel_op {
+                        RelationalOperator::Equals => Ok(Box::new(move |a, b| a == b)),
+                        RelationalOperator::NotEquals => Ok(Box::new(move |a, b| a != b)),
+                        _ => Err(ValidatronError::OperatorNotAllowedOnType(
+                            op,
+                            "bool".to_string(),
+                        )),
+                    },
                     _ => Err(ValidatronError::OperatorNotAllowedOnType(
                         op,
                         "bool".to_string(),
                     )),
-                },
-                _ => Err(ValidatronError::OperatorNotAllowedOnType(
-                    op,
-                    "bool".to_string(),
-                )),
-            }),
-        )
+                }),
+            )
+            .build()
     }
 }
 
 impl<T: Validatron + Send + Sync + 'static> Validatron for Vec<T> {
     fn get_class() -> ValidatronClass {
-        Self::class_builder().collection::<T>()
+        Self::class_builder().collection_clas_builder::<T>().build()
     }
 }
 
 impl Validatron for IpAddr {
     fn get_class() -> ValidatronClass {
-        Self::class_builder().primitive(
-            Box::new(move |s| {
-                IpAddr::from_str(s)
-                    .map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
-            }),
-            Box::new(|op| match op {
-                Operator::Relational(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
-                _ => Err(ValidatronError::OperatorNotAllowedOnType(
-                    op,
-                    "IpAddr".to_string(),
-                )),
-            }),
-        )
+        Self::class_builder()
+            .primitive_class_builder(
+                Box::new(move |s| {
+                    IpAddr::from_str(s)
+                        .map_err(|_| ValidatronError::FieldValueParseError(s.to_string()))
+                }),
+                Box::new(|op| match op {
+                    Operator::Relational(op) => Ok(Box::new(move |a, b| op.apply(a, b))),
+                    _ => Err(ValidatronError::OperatorNotAllowedOnType(
+                        op,
+                        "IpAddr".to_string(),
+                    )),
+                }),
+            )
+            .build()
+    }
+}
+
+impl<T: Validatron + Send + Sync + 'static> Validatron for Option<T> {
+    fn get_class() -> ValidatronClass {
+        Self::class_builder()
+            .enum_class_builder()
+            .add_method0("is_some", Box::new(|c| c.is_some()))
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{validator::get_valid_unary_rule, Identifier, MethodCall};
+
+    #[test]
+    fn test_option_no_method() {
+        let rule = get_valid_unary_rule::<Option<i32>>(vec![Identifier::MethodCall(MethodCall {
+            name: "emos_si".to_string(),
+        })]);
+
+        assert!(rule.is_err());
+    }
+
+    #[test]
+    fn test_option_positive() {
+        let rule = get_valid_unary_rule::<Option<i32>>(vec![Identifier::MethodCall(MethodCall {
+            name: "is_some".to_string(),
+        })])
+        .unwrap();
+
+        let test = Some(666);
+
+        assert!(rule.is_match(&test));
+    }
+
+    #[test]
+    fn test_option_negative() {
+        let rule = get_valid_unary_rule::<Option<i32>>(vec![Identifier::MethodCall(MethodCall {
+            name: "is_some".to_string(),
+        })])
+        .unwrap();
+
+        let test = None;
+
+        assert!(!rule.is_match(&test));
     }
 }

--- a/crates/validatron/src/error.rs
+++ b/crates/validatron/src/error.rs
@@ -22,4 +22,12 @@ pub enum ValidatronError {
     DifferentFieldsType,
     #[error("Collection value not primitive")]
     CollectionValueNotPrimitive,
+    #[error("Method call is not the last identifier")]
+    MethodCallNotLastIdentifier,
+    #[error("Method not found: {0}")]
+    MethodNotFound(String),
+    #[error("Unary expression field not primitive: {0}")]
+    UnaryExpressionFieldNotPrimitive(String),
+    #[error("Unary expression field not bool: {0}")]
+    UnaryExpressionFieldNotBool(String),
 }

--- a/crates/validatron/src/lib.rs
+++ b/crates/validatron/src/lib.rs
@@ -3,7 +3,7 @@
 //! It check if fields specified in a rules are valid for a given type. Example:
 //!
 //! ```
-//! use validatron::{validator::get_valid_rule, Validatron, Field, Identifier, RValue, RelationalOperator, Operator};
+//! use validatron::{validator::get_valid_rule, Validatron, Field, Identifier, RValue, RelationalOperator, Operator, SimpleField};
 //!
 //! #[derive(Validatron)]
 //! struct MyStruct {
@@ -11,9 +11,9 @@
 //! }
 //!
 //! let rule = get_valid_rule::<MyStruct>(
-//!     vec![Identifier::Field(Field::Simple {
-//!         field_name: "my_value".to_string(),
-//!     })],
+//!     vec![Identifier::Field(Field::Simple(SimpleField(
+//!         "my_value".to_string(),
+//!     )))],
 //!     Operator::Relational(RelationalOperator::Equals),
 //!     RValue::Value("42".to_string()),
 //! )
@@ -30,7 +30,7 @@
 //! On top of this it's possible to write complex rules, assembling conditions with logical operators (AND, OR, NOT). Example:
 //!
 //! ```
-//! use validatron::{Ruleset, Rule, Validatron, Operator, RelationalOperator, Condition, Identifier, RValue, Field};
+//! use validatron::{Ruleset, Rule, Validatron, Operator, RelationalOperator, Condition, Identifier, RValue, Field, SimpleField};
 //!
 //! #[derive(Validatron)]
 //! struct MyStruct {
@@ -42,16 +42,16 @@
 //!         name: "my_value equal to 3 or 5".to_string(),
 //!         condition: Condition::Or {
 //!             l: Box::new(Condition::Binary {
-//!                 l: vec![Identifier::Field(Field::Simple {
-//!                     field_name: "my_value".to_string(),
-//!                 })],
+//!                 l: vec![Identifier::Field(Field::Simple(SimpleField(
+//!                     "my_value".to_string()
+//!                 )))],
 //!                 op: Operator::Relational(RelationalOperator::Equals),
 //!                 r: RValue::Value("3".to_string()),
 //!             }),
 //!             r: Box::new(Condition::Binary {
-//!                 l: vec![Identifier::Field(Field::Simple {
-//!                     field_name: "my_value".to_string(),
-//!                 })],
+//!                 l: vec![Identifier::Field(Field::Simple(SimpleField(
+//!                     "my_value".to_string()
+//!                 )))],
 //!                 op: Operator::Relational(RelationalOperator::Equals),
 //!                 r: RValue::Value("5".to_string()),
 //!             }),
@@ -60,9 +60,9 @@
 //!     Rule {
 //!         name: "my_value greater than 100".to_string(),
 //!         condition: Condition::Binary {
-//!             l: vec![Identifier::Field(Field::Simple {
-//!                 field_name: "my_value".to_string(),
-//!             })],
+//!             l: vec![Identifier::Field(Field::Simple(SimpleField(
+//!                 "my_value".to_string()
+//!             )))],
 //!             op: Operator::Relational(RelationalOperator::Greater),
 //!             r: RValue::Value("100".to_string()),
 //!         },
@@ -158,18 +158,26 @@ pub enum Identifier {
 #[serde(tag = "type", content = "content")]
 pub enum Field {
     /// struct field
-    Simple { field_name: String },
+    Simple(SimpleField),
     /// enum field
-    Adt {
-        variant_name: String,
-        field_name: String,
-    },
+    Adt(AdtField),
 }
 
-/// Respresents a method call on an identifier
+/// Represents a simple field
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SimpleField(pub String);
+
+/// Represents an adt field
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdtField {
+    pub variant_name: String,
+    pub field_name: String,
+}
+
+/// Respresents a method call
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MethodCall {
-    name: String,
+    pub name: String,
 }
 
 /// Argument of the operator. It can be a simple [String] or it can be another field represented as

--- a/crates/validatron/src/operators.rs
+++ b/crates/validatron/src/operators.rs
@@ -34,6 +34,7 @@ impl fmt::Display for Operator {
 
 /// Operators intended to be used on strings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "content")]
 pub enum StringOperator {
     StartsWith,
     EndsWith,
@@ -51,6 +52,7 @@ impl StringOperator {
 
 /// Relational operators.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "content")]
 pub enum RelationalOperator {
     Equals,
     NotEquals,
@@ -81,6 +83,7 @@ impl fmt::Display for RelationalOperator {
 
 /// Operators intended to be used on for collections.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "content")]
 pub enum MultiOperator {
     Contains,
 }

--- a/crates/validatron/src/reflection/methods.rs
+++ b/crates/validatron/src/reflection/methods.rs
@@ -1,0 +1,172 @@
+use std::{
+    any::{type_name, Any},
+    collections::HashMap,
+    marker::PhantomData,
+};
+
+use crate::{Validatron, ValidatronClass};
+
+// Extractor closure which gets an object of type F from an object of type T
+pub(super) type Method0CallFn<T, F> = Box<dyn Fn(&T) -> F + Send + Sync>;
+
+// Closures to extract a field from a struct object.
+// These closure types work over dyn Any to simplify code, but expect to be called with
+// the correct type.
+// For maximum performance, the unchecked version will blindly assume the input type to be correct.
+// When unsure about input correctness, the normal version must be called, which will return None
+// when the input type is wrong.
+type DynMethod0CallFn = Box<dyn (Fn(&dyn Any) -> Option<Box<dyn Any>>) + Send + Sync>;
+type UncheckedDynMethod0CallFn = Box<dyn (Fn(&dyn Any) -> Box<dyn Any>) + Send + Sync>;
+
+pub struct MethodsBuilder<T> {
+    class_name: &'static str,
+    methods: HashMap<&'static str, Method>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Validatron + 'static> MethodsBuilder<T> {
+    pub(super) fn new() -> Self {
+        Self {
+            class_name: type_name::<T>(),
+            methods: HashMap::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    // TODO: decide if implement a parametric variant: can be parametric
+    // over access_function but costs size due to monomorphization T*F,
+    // but cost should be minimal because of the body of the function
+    /// Insert a field into the struct definition.
+    pub fn add_method0<F: Validatron + 'static>(
+        mut self,
+        name: &'static str,
+        execute_fn: Method0CallFn<T, F>,
+    ) -> Self {
+        let method_type = MethodType0::<T, F> {
+            executor: execute_fn,
+        };
+
+        let attribute = Method {
+            name,
+            parent_class_name: self.class_name,
+            inner: Box::new(method_type),
+        };
+
+        add_method(&mut self.methods, name, attribute);
+
+        self
+    }
+
+    pub(crate) fn build(self) -> Methods {
+        Methods {
+            name: self.class_name,
+            methods: self.methods,
+        }
+    }
+}
+
+// no monomorphization helper
+fn add_method(
+    methods_map: &mut HashMap<&'static str, Method>,
+    name: &'static str,
+    attribute: Method,
+) {
+    if methods_map.insert(name, attribute).is_some() {
+        panic!("you added two field with the same name '{name}' into a struct class definition")
+    }
+}
+
+/// Methods type representation.
+pub struct Methods {
+    name: &'static str,
+    methods: HashMap<&'static str, Method>,
+}
+
+impl Methods {
+    pub fn get_name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn get_method(&self, field_name: &str) -> Option<&Method> {
+        self.methods.get(field_name)
+    }
+
+    pub fn get_method_owned(mut self, field_name: &str) -> Option<Method> {
+        self.methods.remove(field_name)
+    }
+}
+
+/// Method type representation.
+pub struct Method {
+    name: &'static str,
+    parent_class_name: &'static str,
+    inner: Box<dyn MethodTypeDyn>,
+}
+
+impl Method {
+    pub fn get_name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn get_parent_class_name(&self) -> &'static str {
+        self.parent_class_name
+    }
+
+    pub fn get_class(&self) -> ValidatronClass {
+        self.inner.get_class()
+    }
+
+    pub fn into_extractor_fn(self) -> DynMethod0CallFn {
+        self.inner.into_extractor_fn()
+    }
+
+    /// # Safety
+    ///
+    /// The `unsafe` is related to the returned function. That function accepts values as [Any],
+    /// but must be called with values of the right type, because it doesn't perform checks.
+    pub unsafe fn into_extractor_fn_unchecked(self) -> UncheckedDynMethod0CallFn {
+        self.inner.into_extractor_fn_unchecked()
+    }
+}
+
+trait MethodTypeDyn {
+    fn get_class(&self) -> ValidatronClass;
+
+    fn into_extractor_fn(self: Box<Self>) -> DynMethod0CallFn;
+
+    unsafe fn into_extractor_fn_unchecked(self: Box<Self>) -> UncheckedDynMethod0CallFn;
+}
+
+struct MethodType0<T, F>
+where
+    T: Validatron,
+    F: Validatron,
+{
+    executor: Box<dyn Fn(&T) -> F + Send + Sync>,
+}
+
+impl<T, F> MethodTypeDyn for MethodType0<T, F>
+where
+    T: Validatron + 'static,
+    F: Validatron + 'static,
+{
+    fn get_class(&self) -> ValidatronClass {
+        F::get_class()
+    }
+
+    fn into_extractor_fn(self: Box<Self>) -> DynMethod0CallFn {
+        Box::new(move |source| {
+            source
+                .downcast_ref()
+                .map(|source| Box::new((self.executor)(source)) as _)
+        })
+    }
+
+    unsafe fn into_extractor_fn_unchecked(self: Box<Self>) -> UncheckedDynMethod0CallFn {
+        Box::new(move |source| {
+            let source = &*(source as *const dyn Any as *const T);
+
+            Box::new((self.executor)(source)) as _
+        })
+    }
+}

--- a/pulsar-install.sh
+++ b/pulsar-install.sh
@@ -100,8 +100,9 @@ main() {
     ensure downloader "https://raw.githubusercontent.com/Exein-io/pulsar/main/scripts/pulsar" "${_dir}/pulsar"
     ensure downloader "https://raw.githubusercontent.com/Exein-io/pulsar/main/scripts/pulsard" "${_dir}/pulsard"
 
-    # Download basic rules
+    # Download rules
     ensure downloader "https://raw.githubusercontent.com/Exein-io/pulsar/main/rules/basic-rules.yaml" "${_dir}/basic-rules.yaml"
+    ensure downloader "https://raw.githubusercontent.com/Exein-io/pulsar/main/rules/container-rules.yaml" "${_dir}/container-rules.yaml"
 
     printf '%s\n' 'info: installing files' 1>&2
 
@@ -137,8 +138,9 @@ main() {
 
     printf '%s\n' 'info: basic rules' 1>&2
 
-    # Install basic rules
+    # Install rules
     ensure $_install -m 644 "${_dir}/basic-rules.yaml" ${_pulsar_rules_dir}
+    ensure $_install -m 644 "${_dir}/container-rules.yaml" ${_pulsar_rules_dir}
 
     printf '%s\n' 'info: cleaning' 1>&2
     ignore rm -rf "$_dir"

--- a/rules/container-rules.yaml
+++ b/rules/container-rules.yaml
@@ -1,0 +1,20 @@
+- name: Netcat Remote Code Execution in Container
+  type: Exec
+  condition: |
+    header.container.is_some() AND
+    (
+      (
+        payload.filename ENDS_WITH "/nc" AND (
+          payload.argv CONTAINS "-e" OR
+          payload.argv CONTAINS "-c"
+        )
+      ) OR (
+        payload.filename ENDS_WITH "/ncat" AND (
+          payload.argv CONTAINS "--sh-exec" OR
+          payload.argv CONTAINS "--exec" OR
+          payload.argv CONTAINS "-e" OR
+          payload.argv CONTAINS "-c" OR
+          payload.argv CONTAINS "--lua-exec"
+        )
+      )
+    )


### PR DESCRIPTION
This PR adds the folowing features:
- methods call in dsl
- unary expression in dsl

The final goal is to be able to check the following expression as condition:
```
header.container_info.is_some()
```

This PR also want to add full support for `Option<T>` fields. The syntax to access a field of an optional type is for example:
```
header.container?.image == "archlinux"
``` 

### Current state

- [x] methods support in `validatron`
- [x] unary expressions support in `validatron`
- [x] dsl methods support
- [x] `Option<T>` support in validatron
- [x] `Option<T>` support in dsl
