### PR TITLE
fix(ci): latest release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,7 +239,7 @@ jobs:
             $(docker image ls --format '{{.Repository}}:{{.Tag}}' '${{ env.TMP_LOCAL_IMAGE }}' | tr '\n' ' ')
 
       - name: Push to latest
-        if: github.event.ref_type == 'tag'
+        if: github.ref_type == 'tag'
         run: |
           docker tag ${{ env.REGISTRY_IMAGE }}:${{ env.REGISTRY_TAG }} ${{ env.REGISTRY_IMAGE }}:latest
           docker push ${{ env.REGISTRY_IMAGE }}:latest


### PR DESCRIPTION
this should solve the ci issue we got with the latest tag, where a container was created for the specified tag but a `latest` container was not