### PR TITLE
fix: Handle containers which were running before Pulsar

### DIFF
--- a/crates/bpf-common/src/parsing/containers.rs
+++ b/crates/bpf-common/src/parsing/containers.rs
@@ -43,6 +43,15 @@ pub enum ContainerId {
     Libpod(String),
 }
 
+impl fmt::Display for ContainerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ContainerId::Docker(id) => write!(f, "{id}"),
+            ContainerId::Libpod(id) => write!(f, "{id}"),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct DockerConfig {
     #[serde(rename = "Config")]

--- a/crates/bpf-common/src/parsing/procfs.rs
+++ b/crates/bpf-common/src/parsing/procfs.rs
@@ -178,6 +178,10 @@ fn get_container_id_from_cgroup(cgroup_info: &str) -> Option<ContainerId> {
 }
 
 pub fn get_process_container_id(pid: Pid) -> Result<Option<ContainerId>, ProcfsError> {
+    if pid.as_raw() == 0 {
+        return Ok(None);
+    }
+
     let path = format!("/proc/{pid}/cgroup");
     let file = File::open(&path).map_err(|source| ProcfsError::ReadFile { source, path })?;
 

--- a/crates/bpf-filtering/src/process_tree.rs
+++ b/crates/bpf-filtering/src/process_tree.rs
@@ -66,12 +66,14 @@ fn get_process_namespace(pid: Pid, ns_type: &str) -> Result<u32, Error> {
 fn get_process_namespace_or_log(pid: Pid, namespace_type: &str) -> u32 {
     get_process_namespace(pid, namespace_type).map_or_else(
         |e| {
-            log::warn!(
-                "Failed to determine {} namespace for process {:?}: {}",
-                namespace_type,
-                pid,
-                e
-            );
+            if pid.as_raw() != 0 {
+                log::warn!(
+                    "Failed to determine {} namespace for process {:?}: {}",
+                    namespace_type,
+                    pid,
+                    e
+                );
+            }
             u32::default()
         },
         |v| v,


### PR DESCRIPTION
Always check whether a detected process belongs to a container-related cgroup. This way we ensure that we are adding container info even when the container was created before Pulsar was launched.