### PR TITLE
fix(file-system-monitor): De-duplicate `FileOpen` alerts for containers

### DIFF
--- a/crates/modules/file-system-monitor/probes.bpf.c
+++ b/crates/modules/file-system-monitor/probes.bpf.c
@@ -92,6 +92,12 @@ static __always_inline void on_file_open(void *ctx, struct file *file) {
   pid_t tgid = tracker_interesting_tgid(&GLOBAL_INTEREST_MAP);
   if (tgid < 0)
     return;
+  unsigned int flags = BPF_CORE_READ(file, f_flags);
+  // This bit is present in file flags during the second, duplicate trigger of
+  // the `file_open` hook when running inside container. When the bit is
+  // present, just stop the program.
+  if (flags & 01000000)
+    return;
   struct fs_event *event = init_fs_event(FILE_OPENED, tgid);
   if (!event)
     return;


### PR DESCRIPTION
When reading files inside container, the `file_open` LSM hook gets triggered twice. Before this change, it resulted in threat alerts being issued twice in case the opened file matched a rule.

The only difference which can be spotted between `struct file` instances in both calls of `file_open` is an additional bit in `file->f_flags` during the second call.

When calling `cat /etc/shadow` inside container, the `f_flags` are respectively:

* `131072` (`0x1000000000000000000`)
* `393216` (`0x1100000000000000000`)