### PR TITLE
rule engine dsl: fix one char value

### DIFF
--- a/crates/modules/rules-engine/src/dsl.lalrpop
+++ b/crates/modules/rules-engine/src/dsl.lalrpop
@@ -69,7 +69,7 @@ Comma<T>: Vec<T> = {
 }
 
 Value: String = {
-    r#"".[^\s]+""# => <>.trim_matches('"').to_string(),
+    r#""\S+""# => <>.trim_matches('"').to_string(),
     r"[0-9]+" => <>.to_string()
 }
 

--- a/crates/modules/rules-engine/src/dsl.rs
+++ b/crates/modules/rules-engine/src/dsl.rs
@@ -465,4 +465,19 @@ mod tests {
         };
         assert_eq!(parsed, expected);
     }
+
+    #[test]
+    fn one_character_value_start() {
+        let parsed = dsl::ConditionParser::new()
+            .parse("Exec", r#"a == "3""#)
+            .unwrap();
+        let expected = Condition::Base {
+            field_path: vec![Field::Simple {
+                field_name: "a".to_string(),
+            }],
+            op: Operator::Relational(RelationalOperator::Equals),
+            value: Match::Value("3".to_string()),
+        };
+        assert_eq!(parsed, expected);
+    }
 }


### PR DESCRIPTION
This PR fixes the issue of parsing one character strings in the rule engine DSL
