### PR TITLE
chore: Include riscv64gc in pulsar-install.sh

### DIFF
--- a/pulsar-install.sh
+++ b/pulsar-install.sh
@@ -253,8 +253,8 @@ get_release_variant() {
             ;;
 
         riscv64)
-            # TODO: _cputype=riscv64gc
-            err "installer unsupported CPU type: $_cputype. You have to manually build youself for $_cputype"
+            #_cputype=riscv64gc
+            _arch=riscv64gc
             ;;
 
         *)


### PR DESCRIPTION
We already include riscv64gc binaries in releases, so we can also use them in the install script.