### PR TITLE
fix(network-filter): DNS event generation

### DIFF
--- a/crates/modules/network-monitor/probes.bpf.c
+++ b/crates/modules/network-monitor/probes.bpf.c
@@ -360,7 +360,7 @@ static __always_inline void
 static __always_inline void
 read_sk_buff(struct buffer *buffer, struct msg_event *output,
              struct __sk_buff *skb, __u32 offset) {
-  size_t len = output->data_len - offset;
+  size_t len = output->data_len - 1;
 
   if (len > MAX_DATA_SIZE) {
      LOG_DEBUG("len=%d MAX_DATA_SIZE=%d", len, MAX_DATA_SIZE);    
@@ -534,7 +534,8 @@ int skb_ingress(struct __sk_buff *skb) {
   struct arguments *args = bpf_map_lookup_elem(&args_map, &tgid);
   int r = bpf_map_delete_elem(&args_map, &tgid);
   if (!args) {
-    return CGROUP_SKB_OK;
+    LOG_DEBUG("cgroup_skb/ingress: args is null");
+    //return CGROUP_SKB_OK;
   }
 
   struct network_event *event = init_network_event(EVENT_RECV, tgid);
@@ -562,11 +563,13 @@ int skb_ingress(struct __sk_buff *skb) {
       // NOTE: msg_name is NULL if the userspace code is not interested
       // in knowing the source of the message. In that case we won't extract
       // the source port and address.
-      struct sockaddr *addr = args->data[2];
-      if (!addr) {
-        LOG_DEBUG("sockaddr is null. ");
-      } else {
-        copy_sockaddr(addr, &event->recv.destination, true);
+      if (args){
+        struct sockaddr *addr = args->data[2];
+        if (!addr) {
+          LOG_DEBUG("sockaddr is null. ");
+        } else {
+          copy_sockaddr(addr, &event->recv.destination, true);
+        }
       }
     } else {
       event->send.data.len = 0;
@@ -591,11 +594,13 @@ int skb_ingress(struct __sk_buff *skb) {
       // NOTE: msg_name is NULL if the userspace code is not interested
       // in knowing the source of the message. In that case we won't extract
       // the source port and address.
-      struct sockaddr *addr = args->data[2];
-      if (!addr) {
-        LOG_DEBUG("sockaddr is null. ");
-      } else {
-        copy_sockaddr(addr, &event->recv.destination, true);
+      if (args){
+        struct sockaddr *addr = args->data[2];
+        if (!addr) {
+          LOG_DEBUG("sockaddr is null. ");
+        } else {
+          copy_sockaddr(addr, &event->recv.destination, true);
+        }
       }
     } else {
       event->send.data.len = 0;


### PR DESCRIPTION
# Pull Request Title

Pulsar IOT was not successfully generating DNS queries/answers information. 

## Implementation (Optional)

First the amount of data read is now corresponding to the data len - 1 in the packet (excl IP and UDP headers). Review is welcome on this point since that does not work if "len = output->data_len" (i.e. the exact size of the data in the packet) but with "len = output->data_len - 1".

For the data reception, destination address retrieval of the incoming packet is skipped. Actually we do not really care about this adress since it should be an adress of one of the network interface...

## I have 

- [ ] run `cargo fmt`;
- [ ] run `cargo clippy`;
- [ ] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
