### PR TITLE
fix filtering test

### DIFF
--- a/crates/bpf-filtering/src/filtering_example.bpf.c
+++ b/crates/bpf-filtering/src/filtering_example.bpf.c
@@ -6,7 +6,7 @@ MAP_CGROUP_RULES(m_cgroup_rules);
 MAP_INTEREST(m_interest, PINNING_DISABLED);
 
 SEC("raw_tracepoint/sched_process_fork")
-int BPF_PROG(process_fork, struct task_struct *parent,
+int BPF_PROG(sched_process_fork, struct task_struct *parent,
              struct task_struct *child) {
   tracker_fork(&m_interest, parent, child);
   return 0;
@@ -20,7 +20,7 @@ int BPF_PROG(sched_process_exec, struct task_struct *p, pid_t old_pid,
 }
 
 SEC("raw_tracepoint/sched_process_exit")
-int BPF_PROG(process_exit, struct task_struct *p) {
+int BPF_PROG(sched_process_exit, struct task_struct *p) {
   tracker_remove(&m_interest, p);
   return 0;
 }

--- a/crates/bpf-filtering/src/test_suite.rs
+++ b/crates/bpf-filtering/src/test_suite.rs
@@ -365,7 +365,7 @@ fn load_ebpf() -> Bpf {
         false,
     )
     .unwrap();
-    const PIN_PATH: &str = "/sys/fs/bpf/anomaly-detection-test";
+    const PIN_PATH: &str = "/sys/fs/bpf/filtering-test";
     let _ = std::fs::create_dir(PIN_PATH);
     let bpf = BpfLoader::new()
         .map_pin_path(PIN_PATH)


### PR DESCRIPTION
The test was failing because of an update of aya on how it access bpf function inside the bpf probe
