### PR TITLE
fix(network-monitor): Integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,3 +59,19 @@ jobs:
 
       - name: Unit tests
         run: cross test --locked --target=${{ matrix.platform.target }} --workspace --all-targets ${{ matrix.platform.args }}
+
+      - name: Install dependencies
+        if: matrix.platform.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
+          echo /usr/lib/llvm-17/bin >> $GITHUB_PATH
+
+      - name: Integration tests (native)
+        if: matrix.platform.target == 'x86_64-unknown-linux-gnu'
+        run: cargo xtask test
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/crates/modules/network-monitor/probes.bpf.c
+++ b/crates/modules/network-monitor/probes.bpf.c
@@ -505,6 +505,9 @@ int skb_egress(struct __sk_buff *skb) {
   }
 
 output:
+  copy_skc_source(&sk->__sk_common, &event->send.source);
+  copy_skc_dest(&sk->__sk_common, &event->send.destination);
+
   output_network_event(skb, event);
   return CGROUP_SKB_OK;
 }


### PR DESCRIPTION
Addresses several bugs which triggered failures of test-suite:

* The `send` event contained only the message, but
not the addresses (source and destination).