### PR TITLE
chore(bpf-common): Ignore Clippy warning about unused `StopHandle` field

### DIFF
--- a/crates/bpf-common/src/trace_pipe.rs
+++ b/crates/bpf-common/src/trace_pipe.rs
@@ -13,6 +13,7 @@ use tokio_fd::AsyncFd;
 
 const PATH: &str = "/sys/kernel/debug/tracing/trace_pipe";
 
+#[allow(unused)]
 pub struct StopHandle(oneshot::Sender<()>);
 
 pub async fn start() -> StopHandle {


### PR DESCRIPTION
The only purpose of `StopHandle` is the ability to drop the sender side of the channel explicitly when the daemon stops. Therefore, ignore the clippy warning about it being unused.
