### PR TITLE
refactor: Replace `LINUX_KERNEL_VERSION` checks with checks on `bpf_func_id`

### DIFF
--- a/crates/bpf-builder/include/loop.bpf.h
+++ b/crates/bpf-builder/include/loop.bpf.h
@@ -16,7 +16,7 @@
 // function seems to cause issues.
 #ifdef FEATURE_FN_POINTERS
 #define LOOP(max_iterations, max_unroll, callback_fn, ctx)                     \
-  if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 17, 0)) {                      \
+  if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_loop)) {           \
     bpf_loop(max_iterations, callback_fn, ctx, 0);                             \
   } else {                                                                     \
     _Pragma("unroll") for (int i = 0; i < max_unroll; i++) {                   \

--- a/crates/bpf-builder/include/strncmp.bpf.h
+++ b/crates/bpf-builder/include/strncmp.bpf.h
@@ -7,7 +7,8 @@
 #define STRNCMP(s1, s1_sz, s2)                                    \
     ({                                                            \
         int result;                                               \
-        if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 17, 0))     \
+        if (bpf_core_enum_value_exists(enum bpf_func_id,          \
+                                       BPF_FUNC_strncmp))         \
         {                                                         \
             result = bpf_strncmp(s1, s1_sz, s2);                  \
         }                                                         \


### PR DESCRIPTION
Checking kernel version is not the most reliable way of determining whether a given BPF feature is present in the kernel. Many distributions backport BPF features to older kernel versions.

Kernel provides the `enum bpf_func_id` which contains `BPF_FUNC_*` variants. In combination with `bpf_core_enum_value_exists`, it can be used to determine whether the given function is supported by the running kernel.

Fixes: #261 