### PR TITLE
feat: Include inode of executable in `Exec` and `Fork` events

### DIFF
--- a/crates/bpf-filtering/src/initializer.rs
+++ b/crates/bpf-filtering/src/initializer.rs
@@ -74,6 +74,7 @@ pub async fn setup_events_filter(
             ppid: process.parent,
             pid: process.pid,
             uid: process.uid,
+            exe_inode: process.exe_inode,
             timestamp: Timestamp::from(0),
             namespaces: process.namespaces,
             container_id: process.container_id.clone(),
@@ -81,6 +82,7 @@ pub async fn setup_events_filter(
         process_tracker.update(TrackerUpdate::Exec {
             pid: process.pid,
             uid: process.uid,
+            exe_inode: process.exe_inode,
             image: process.image.to_string(),
             timestamp: Timestamp::from(0),
             argv: Vec::new(),

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -46,7 +46,7 @@ impl fmt::Display for Event {
 
                 format!("{container_image} {container_image_digest} {image} ({pid})")
             }
-            None => format!("{image} ({pid})"),
+            None => format!("{image} {{ pid: {pid}, exe_inode: {} }}", header.exe_inode),
         };
 
         if let Some(Threat {
@@ -82,6 +82,7 @@ pub struct Header {
     pub image: String,
     pub pid: i32,
     pub parent_pid: i32,
+    pub exe_inode: Inode,
     pub container: Option<ContainerInfo>,
     #[validatron(skip)]
     pub threat: Option<Threat>,
@@ -550,6 +551,19 @@ impl fmt::Display for Namespaces {
             "{{ uts: {}, ipc: {}, mnt: {}, pid: {}, net: {}, time: {}, cgroup: {} }}",
             self.uts, self.ipc, self.mnt, self.pid, self.net, self.time, self.cgroup
         )
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Validatron)]
+pub struct Inode {
+    pub ino: u64,
+    pub rdev: u64,
+}
+
+impl fmt::Display for Inode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{ ino: {}, rdev: {} }}", self.ino, self.rdev)
     }
 }
 

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt, future::Future, ops::Deref, sync::Arc, time::UNIX_EP
 
 use crate::{
     bus::{Bus, BusError},
-    event::{Event, Header, Payload, Threat, Value},
+    event::{Event, Header, Inode, Payload, Threat, Value},
 };
 use anyhow::Result;
 use bpf_common::{program::BpfEvent, time::Timestamp, Pid};
@@ -245,6 +245,7 @@ impl ModuleSender {
                 source: module_name.clone(),
                 threat,
                 pid: process.as_raw(),
+                exe_inode: Inode::default(),
                 timestamp: timestamp.into(),
                 image: String::new(),
                 parent_pid: 0,
@@ -255,6 +256,7 @@ impl ModuleSender {
                 Ok(ProcessInfo {
                     image,
                     ppid,
+                    exe_inode,
                     fork_time,
                     argv: _,
                     namespaces: _,
@@ -262,6 +264,7 @@ impl ModuleSender {
                 }) => {
                     header.image = image;
                     header.parent_pid = ppid.as_raw();
+                    header.exe_inode = exe_inode;
                     header.fork_time = fork_time.into();
                     header.container = container;
                 }


### PR DESCRIPTION
This information is going to be useful for unique distinguising of containerized binaries. The path of the binary logged in events is relative to the root filesystem. By including an inode, we can retrieve a binary file of a containerized process from the host reliably.

For example, given the following event coming from container:

```
[2024-04-08T08:01:30Z EVENT alpine:3.19
sha256:05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd
/bin/sh (11356)] [process-monitor] Fork { ppid: 11332, exe_inode: 5503693 }
```

`/bin/sh` mentioned here refers to a path inside container's filesystem. It's not the same as `/bin/sh` on the host. However, if we ever want to access that binary from the host, we can search for it by the inode `5503693`:

```
# btrfs inspect-internal inode-resolve 5503693 /var/lib/docker
/var/lib/docker/lib/docker/overlay2/ba168125fc8c536a047552f3a16c5a9db7e649092a0fb3ec3321b65530399050/diff/bin/busybox
/var/lib/docker/overlay2/ba168125fc8c536a047552f3a16c5a9db7e649092a0fb3ec3321b65530399050/diff/bin/busybox
```
