### PR TITLE
feat: allow threats to be logged as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,8 @@ dependencies = [
  "bpf-common",
  "log",
  "pulsar-core",
+ "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/crates/modules/logger/Cargo.toml
+++ b/crates/modules/logger/Cargo.toml
@@ -9,5 +9,7 @@ repository.workspace = true
 pulsar-core = { workspace = true }
 bpf-common = { workspace = true }
 
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 log = { workspace = true }

--- a/crates/modules/logger/README.md
+++ b/crates/modules/logger/README.md
@@ -8,6 +8,7 @@ This module will log Pulsar threat events to stdout.
 |------|----|-----------|
 |console|bool|log to stdout|
 |syslog|bool|log to syslog|
+|output_format|string|output format for events (plaintext, json)|
 
 Default configuration:
 
@@ -16,6 +17,7 @@ Default configuration:
 enabled=true
 console=true
 syslog=true
+output_format=plaintext
 ```
 
 You disable this module with:


### PR DESCRIPTION
# Allow threats to be logged as JSON

Issue: https://github.com/exein-io/pulsar/issues/264

This feature allows threat reporting to be output as JSON. Output format can be configured via `pulsar.ini` or at runtime with `pulsar config --set logging.output_format=...`. The default output format is `plaintext` to match the current behavior.

Example JSON output of a file creation threat (from the README):

```json
{"header":{"image":"/usr/bin/ln","pid":36738,"parent_pid":12810,"container":null,"threat":{"source":"rules-engine","description":"Create sensitive files symlink","extra":null},"source":"file-system-monitor","timestamp":{"secs_since_epoch":1713625327,"nanos_since_epoch":832828392},"fork_time":{"secs_since_epoch":1713625327,"nanos_since_epoch":818390681}},"payload":{"type":"FileLink","content":{"source":"/tmp/secret","destination":"/etc/shadow","hard_link":false}}}
```

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
