### PR TITLE
build: Prefer rustls over OpenSSL for static builds

### DIFF
--- a/.cross/aarch64-unknown-linux-musl.Dockerfile
+++ b/.cross/aarch64-unknown-linux-musl.Dockerfile
@@ -7,8 +7,6 @@ RUN dpkg --add-architecture arm64 && \
         wget \
         software-properties-common \
         gnupg \
-        libssl-dev:arm64 \
-        libsqlite3-dev:arm64 \
     && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 \
     && ln -s /usr/bin/clang-17 /usr/bin/clang \
     && ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-musl.Dockerfile
+++ b/.cross/x86_64-unknown-linux-musl.Dockerfile
@@ -6,8 +6,6 @@ RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome >
         wget \
         software-properties-common \
         gnupg \
-        libssl-dev \
-        libsqlite3-dev \
     && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 \
     && ln -s /usr/bin/clang-17 /usr/bin/clang \
     && ln -s /usr/bin/llvm-strip-17 /usr/bin/llvm-strip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,14 +19,14 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds, use the `static` feature.
+          # For `musl` builds, use the `all-vendored` and `tls-rustls` features.
           - target: x86_64-unknown-linux-musl
             args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds, use the `static` feature.
+          # For `musl` builds, use the `all-vendored` and `tls-rustls` features.
           - target: aarch64-unknown-linux-musl
             args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,16 +19,16 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, use the `static` feature.
           - target: x86_64-unknown-linux-musl
-            args: "--features full --features all-vendored"
+            args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, use the `static` feature.
           - target: aarch64-unknown-linux-musl
-            args: "--features full --features all-vendored"
+            args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           # Dependencies of `xtask` might fail to build on riscv64.
           - target: riscv64gc-unknown-linux-gnu

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -49,14 +49,14 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds, use the `static` feature.
+          # For `musl` builds, use the `all-vendored` and `tls-rustls` features.
           - target: x86_64-unknown-linux-musl
             args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds, use the `static` feature.
+          # For `musl` builds, use the `all-vendored` and `tls-rustls` features.
           - target: aarch64-unknown-linux-musl
             args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -49,16 +49,16 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, use the `static` feature.
           - target: x86_64-unknown-linux-musl
-            args: "--features full --features all-vendored"
+            args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full"
 
-          # For `musl` builds openssl must be vendored
+          # For `musl` builds, use the `static` feature.
           - target: aarch64-unknown-linux-musl
-            args: "--features full --features all-vendored"
+            args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           # Dependencies of `xtask` might fail to build on riscv64.
           - target: riscv64gc-unknown-linux-gnu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
               platform: linux/amd64
 
           - target: x86_64-unknown-linux-musl
-            args: "--features full --features all-vendored"
+            args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           - target: aarch64-unknown-linux-gnu
             args: "--features full --features openssl-vendored"
@@ -68,7 +68,7 @@ jobs:
               platform: linux/arm64
           
           - target: aarch64-unknown-linux-musl
-            args: "--features full --features all-vendored"
+            args: "--no-default-features --features full --features all-vendored --features tls-rustls"
 
           - target: riscv64gc-unknown-linux-gnu
             args: "--features full --features openssl-vendored"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.21.7",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -264,6 +264,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bit-set"
@@ -705,7 +711,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfb21b9878cf7a348dcb8559109aabc0ec40d69924bd706fa5149846c4fef75"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "memchr",
 ]
 
@@ -1133,9 +1139,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1314,7 +1320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357ff5edb6d8326473a64c82cf41ddf78ab116f89668c50c4fac1b321e5e80f4"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "chumsky",
  "email-encoding",
  "email_address",
@@ -1328,10 +1334,14 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
+ "rustls 0.22.3",
+ "rustls-pemfile 2.1.2",
  "socket2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.25.0",
  "url",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -2021,7 +2031,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2038,21 +2048,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -2125,8 +2135,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2135,8 +2159,24 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -2145,6 +2185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2440,6 +2491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,7 +2735,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3068,6 +3136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,3 +3387,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,12 @@ semver = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["full"]
+default = ["full", "tls-openssl"]
 full = ["core", "extra"]
 core = ["logger", "process-monitor", "network-monitor", "file-system-monitor"]
 extra = ["rules-engine", "desktop-notifier", "smtp-notifier"]
+tls-openssl = ["smtp-notifier/tls-openssl"]
+tls-rustls = ["smtp-notifier/tls-rustls"]
 all-vendored = ["openssl-vendored", "sqlite3-vendored"]
 openssl-vendored = ["smtp-notifier?/openssl-vendored"]
 sqlite3-vendored = ["bpf-common/sqlite3-vendored"]

--- a/crates/modules/smtp-notifier/Cargo.toml
+++ b/crates/modules/smtp-notifier/Cargo.toml
@@ -16,11 +16,14 @@ lettre = { workspace = true, features = [
     "tokio1",
     "builder",
 ] }
-openssl = { workspace = true }
+openssl = { workspace = true, optional = true }
 leon = { workspace = true }
 gethostname = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
 
 [features]
-openssl-vendored = ["openssl/vendored"]
+default = ["openssl"]
+tls-openssl = ["openssl", "lettre/tokio1-native-tls"]
+tls-rustls = ["lettre/tokio1-rustls-tls"]
+openssl-vendored = ["openssl?/vendored"]


### PR DESCRIPTION
Introduce the new `static` feature which not only makes all dependencies vendored, but also prefers rustls over OpenSSL. The new underlying features, allowing the choice of TLS implementation, are `tls-openssl` and `tls-rustls`.

OpenSSL is still the default choice when not providing any features.

Since features in Cargo are additive, the `static` feature works properly only with `--no-default-features`. Therefore, the recommended way of performing the static builds is:

```
cross build --target=<triple>-musl --no-default-features --features static
```

Fixes #281 