### PR TITLE
chore: Stop excluding xtask in RISC-V builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,8 @@ jobs:
           - target: aarch64-unknown-linux-musl
             args: "--features full --features all-vendored"
 
-          # Dependencies of `xtask` might fail to build on riscv64.
           - target: riscv64gc-unknown-linux-gnu
-            args: "--features full --exclude xtask"
+            args: "--features full"
 
     steps:
       - name: Code checkout

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -62,7 +62,7 @@ jobs:
 
           # Dependencies of `xtask` might fail to build on riscv64.
           - target: riscv64gc-unknown-linux-gnu
-            args: "--features full --exclude xtask"
+            args: "--features full"
 
     steps:
       - name: Code checkout


### PR DESCRIPTION
Doing so before was necessary because of `ring` builds failing on RISC-V, but that's not the case anymore.