### PR TITLE
modules api: support for an extra function working the state

### DIFF
--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -59,6 +59,7 @@ impl From<PulsarDaemonError> for EngineApiError {
     fn from(error: PulsarDaemonError) -> Self {
         match &error {
             PulsarDaemonError::ModuleNotFound(_) => Self::BadRequest(error.to_string()),
+            PulsarDaemonError::StartError(_) => Self::BadRequest(error.to_string()),
             PulsarDaemonError::StopError(_) => Self::BadRequest(error.to_string()),
             PulsarDaemonError::ConfigurationUpdateError(_) => {
                 log::error!("Unexpected Error {}", error.to_string());

--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -6,15 +6,14 @@ use std::{
 use anyhow::Context;
 use pulsar_core::{
     event::Threat,
-    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule},
+    pdk::{BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError},
 };
 
 pub struct DesktopNotifierModule;
 
-impl PulsarModule for DesktopNotifierModule {
+impl BasicPulsarModule for DesktopNotifierModule {
     type Config = Config;
     type State = ();
-    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "desktop-notifier";
     const DEFAULT_ENABLED: bool = false;

--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -6,12 +6,12 @@ use std::{
 use anyhow::Context;
 use pulsar_core::{
     event::Threat,
-    pdk::{BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError},
+    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, SimplePulsarModule},
 };
 
 pub struct DesktopNotifierModule;
 
-impl BasicPulsarModule for DesktopNotifierModule {
+impl SimplePulsarModule for DesktopNotifierModule {
     type Config = Config;
     type State = ();
 

--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::Context;
 use pulsar_core::{
     event::Threat,
-    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, PulsarModule},
+    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule},
 };
 
 pub struct DesktopNotifierModule;
@@ -14,6 +14,7 @@ pub struct DesktopNotifierModule;
 impl PulsarModule for DesktopNotifierModule {
     type Config = Config;
     type State = ();
+    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "desktop-notifier";
     const DEFAULT_ENABLED: bool = false;

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -83,15 +83,15 @@ pub mod pulsar {
     use pulsar_core::{
         event::FileFlags,
         pdk::{
-            BasicPulsarModule, ConfigError, Event, IntoPayload, ModuleConfig, ModuleContext,
-            ModuleError, Payload,
+            ConfigError, Event, IntoPayload, ModuleConfig, ModuleContext, ModuleError, Payload,
+            SimplePulsarModule,
         },
     };
     use tokio::{fs::File, io::AsyncReadExt};
 
     pub struct FileSystemMonitorModule;
 
-    impl BasicPulsarModule for FileSystemMonitorModule {
+    impl SimplePulsarModule for FileSystemMonitorModule {
         type Config = Config;
         type State = FileSystemMonitorState;
 

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -83,18 +83,17 @@ pub mod pulsar {
     use pulsar_core::{
         event::FileFlags,
         pdk::{
-            ConfigError, Event, IntoPayload, ModuleConfig, ModuleContext, ModuleError, NoExtra,
-            Payload, PulsarModule,
+            BasicPulsarModule, ConfigError, Event, IntoPayload, ModuleConfig, ModuleContext,
+            ModuleError, Payload,
         },
     };
     use tokio::{fs::File, io::AsyncReadExt};
 
     pub struct FileSystemMonitorModule;
 
-    impl PulsarModule for FileSystemMonitorModule {
+    impl BasicPulsarModule for FileSystemMonitorModule {
         type Config = Config;
         type State = FileSystemMonitorState;
-        type Extra = NoExtra;
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -83,8 +83,8 @@ pub mod pulsar {
     use pulsar_core::{
         event::FileFlags,
         pdk::{
-            ConfigError, Event, IntoPayload, ModuleConfig, ModuleContext, ModuleError, Payload,
-            PulsarModule,
+            ConfigError, Event, IntoPayload, ModuleConfig, ModuleContext, ModuleError, NoExtra,
+            Payload, PulsarModule,
         },
     };
     use tokio::{fs::File, io::AsyncReadExt};
@@ -94,6 +94,7 @@ pub mod pulsar {
     impl PulsarModule for FileSystemMonitorModule {
         type Config = Config;
         type State = FileSystemMonitorState;
+        type Extra = NoExtra;
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use pulsar_core::pdk::{
-    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule,
+    BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError,
 };
 use thiserror::Error;
 
@@ -21,10 +21,9 @@ const PRIORITY: u8 = 25; // facility * 8 + severity. facility: daemon (3); sever
 
 pub struct LoggerModule;
 
-impl PulsarModule for LoggerModule {
+impl BasicPulsarModule for LoggerModule {
     type Config = Config;
     type State = LoggerState;
-    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "threat-logger";
     const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use pulsar_core::pdk::{
-    BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError,
+    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, SimplePulsarModule,
 };
 use thiserror::Error;
 
@@ -21,7 +21,7 @@ const PRIORITY: u8 = 25; // facility * 8 + severity. facility: daemon (3); sever
 
 pub struct LoggerModule;
 
-impl BasicPulsarModule for LoggerModule {
+impl SimplePulsarModule for LoggerModule {
     type Config = Config;
     type State = LoggerState;
 

--- a/crates/modules/logger/src/lib.rs
+++ b/crates/modules/logger/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use pulsar_core::pdk::{
-    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, PulsarModule,
+    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule,
 };
 use thiserror::Error;
 
@@ -24,6 +24,7 @@ pub struct LoggerModule;
 impl PulsarModule for LoggerModule {
     type Config = Config;
     type State = LoggerState;
+    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "threat-logger";
     const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -177,7 +177,7 @@ pub mod pulsar {
     use bpf_common::{parsing::IndexError, program::BpfEvent, BpfSenderWrapper};
     use pulsar_core::{
         event::{DnsAnswer, DnsQuestion, Host},
-        pdk::{IntoPayload, ModuleContext, ModuleError, Payload, PulsarModule},
+        pdk::{IntoPayload, ModuleContext, ModuleError, NoExtra, Payload, PulsarModule},
     };
 
     pub struct NetworkMonitorModule;
@@ -185,6 +185,7 @@ pub mod pulsar {
     impl PulsarModule for NetworkMonitorModule {
         type Config = pulsar_core::pdk::NoConfig;
         type State = NetworkMonitorState;
+        type Extra = NoExtra;
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -177,15 +177,14 @@ pub mod pulsar {
     use bpf_common::{parsing::IndexError, program::BpfEvent, BpfSenderWrapper};
     use pulsar_core::{
         event::{DnsAnswer, DnsQuestion, Host},
-        pdk::{IntoPayload, ModuleContext, ModuleError, NoExtra, Payload, PulsarModule},
+        pdk::{BasicPulsarModule, IntoPayload, ModuleContext, ModuleError, Payload},
     };
 
     pub struct NetworkMonitorModule;
 
-    impl PulsarModule for NetworkMonitorModule {
+    impl BasicPulsarModule for NetworkMonitorModule {
         type Config = pulsar_core::pdk::NoConfig;
         type State = NetworkMonitorState;
-        type Extra = NoExtra;
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -177,12 +177,12 @@ pub mod pulsar {
     use bpf_common::{parsing::IndexError, program::BpfEvent, BpfSenderWrapper};
     use pulsar_core::{
         event::{DnsAnswer, DnsQuestion, Host},
-        pdk::{BasicPulsarModule, IntoPayload, ModuleContext, ModuleError, Payload},
+        pdk::{IntoPayload, ModuleContext, ModuleError, Payload, SimplePulsarModule},
     };
 
     pub struct NetworkMonitorModule;
 
-    impl BasicPulsarModule for NetworkMonitorModule {
+    impl SimplePulsarModule for NetworkMonitorModule {
         type Config = pulsar_core::pdk::NoConfig;
         type State = NetworkMonitorState;
 

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -145,14 +145,14 @@ pub mod pulsar {
     use super::*;
     use bpf_common::{containers::ContainerId, program::BpfEvent, BpfSenderWrapper};
     use pulsar_core::pdk::{
-        process_tracker::TrackerUpdate, BasicPulsarModule, IntoPayload, ModuleContext, ModuleError,
-        Payload,
+        process_tracker::TrackerUpdate, IntoPayload, ModuleContext, ModuleError, Payload,
+        SimplePulsarModule,
     };
     use tokio::{sync::mpsc, task::JoinHandle};
 
     pub struct ProcessMonitorModule;
 
-    impl BasicPulsarModule for ProcessMonitorModule {
+    impl SimplePulsarModule for ProcessMonitorModule {
         type Config = bpf_filtering::config::Config;
         type State = ProcessMonitorStatus;
 

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -145,7 +145,7 @@ pub mod pulsar {
     use super::*;
     use bpf_common::{containers::ContainerId, program::BpfEvent, BpfSenderWrapper};
     use pulsar_core::pdk::{
-        process_tracker::TrackerUpdate, IntoPayload, ModuleContext, ModuleError, Payload,
+        process_tracker::TrackerUpdate, IntoPayload, ModuleContext, ModuleError, NoExtra, Payload,
         PulsarModule,
     };
     use tokio::{sync::mpsc, task::JoinHandle};
@@ -155,6 +155,7 @@ pub mod pulsar {
     impl PulsarModule for ProcessMonitorModule {
         type Config = bpf_filtering::config::Config;
         type State = ProcessMonitorStatus;
+        type Extra = NoExtra;
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -145,17 +145,16 @@ pub mod pulsar {
     use super::*;
     use bpf_common::{containers::ContainerId, program::BpfEvent, BpfSenderWrapper};
     use pulsar_core::pdk::{
-        process_tracker::TrackerUpdate, IntoPayload, ModuleContext, ModuleError, NoExtra, Payload,
-        PulsarModule,
+        process_tracker::TrackerUpdate, BasicPulsarModule, IntoPayload, ModuleContext, ModuleError,
+        Payload,
     };
     use tokio::{sync::mpsc, task::JoinHandle};
 
     pub struct ProcessMonitorModule;
 
-    impl PulsarModule for ProcessMonitorModule {
+    impl BasicPulsarModule for ProcessMonitorModule {
         type Config = bpf_filtering::config::Config;
         type State = ProcessMonitorStatus;
-        type Extra = NoExtra;
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/rules-engine/src/lib.rs
+++ b/crates/modules/rules-engine/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use engine::RuleEngine;
 use pulsar_core::pdk::{
-    BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError,
+    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, SimplePulsarModule,
 };
 
 mod dsl;
@@ -15,7 +15,7 @@ const DEFAULT_RULES_PATH: &str = "/var/lib/pulsar/rules";
 
 pub struct RuleEngineModule;
 
-impl BasicPulsarModule for RuleEngineModule {
+impl SimplePulsarModule for RuleEngineModule {
     type Config = Config;
     type State = State;
 

--- a/crates/modules/rules-engine/src/lib.rs
+++ b/crates/modules/rules-engine/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use engine::RuleEngine;
 use pulsar_core::pdk::{
-    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule,
+    BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError,
 };
 
 mod dsl;
@@ -15,10 +15,9 @@ const DEFAULT_RULES_PATH: &str = "/var/lib/pulsar/rules";
 
 pub struct RuleEngineModule;
 
-impl PulsarModule for RuleEngineModule {
+impl BasicPulsarModule for RuleEngineModule {
     type Config = Config;
     type State = State;
-    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "rules-engine";
     const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/rules-engine/src/lib.rs
+++ b/crates/modules/rules-engine/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use engine::RuleEngine;
 use pulsar_core::pdk::{
-    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, PulsarModule,
+    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule,
 };
 
 mod dsl;
@@ -18,6 +18,7 @@ pub struct RuleEngineModule;
 impl PulsarModule for RuleEngineModule {
     type Config = Config;
     type State = State;
+    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "rules-engine";
     const DEFAULT_ENABLED: bool = true;

--- a/crates/modules/smtp-notifier/src/lib.rs
+++ b/crates/modules/smtp-notifier/src/lib.rs
@@ -8,7 +8,7 @@ use lettre::{
 };
 use pulsar_core::{
     event::Threat,
-    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, PulsarModule},
+    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule},
 };
 
 mod template;
@@ -18,6 +18,7 @@ pub struct SmtpNotifierModule;
 impl PulsarModule for SmtpNotifierModule {
     type Config = SmtpNotifierConfig;
     type State = SmtpNotifierState;
+    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "smtp-notifier";
     const DEFAULT_ENABLED: bool = false;

--- a/crates/modules/smtp-notifier/src/lib.rs
+++ b/crates/modules/smtp-notifier/src/lib.rs
@@ -8,17 +8,16 @@ use lettre::{
 };
 use pulsar_core::{
     event::Threat,
-    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, PulsarModule},
+    pdk::{BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError},
 };
 
 mod template;
 
 pub struct SmtpNotifierModule;
 
-impl PulsarModule for SmtpNotifierModule {
+impl BasicPulsarModule for SmtpNotifierModule {
     type Config = SmtpNotifierConfig;
     type State = SmtpNotifierState;
-    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "smtp-notifier";
     const DEFAULT_ENABLED: bool = false;

--- a/crates/modules/smtp-notifier/src/lib.rs
+++ b/crates/modules/smtp-notifier/src/lib.rs
@@ -8,14 +8,14 @@ use lettre::{
 };
 use pulsar_core::{
     event::Threat,
-    pdk::{BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError},
+    pdk::{ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, SimplePulsarModule},
 };
 
 mod template;
 
 pub struct SmtpNotifierModule;
 
-impl BasicPulsarModule for SmtpNotifierModule {
+impl SimplePulsarModule for SmtpNotifierModule {
     type Config = SmtpNotifierConfig;
     type State = SmtpNotifierState;
 

--- a/crates/pulsar-core/src/pdk/daemon.rs
+++ b/crates/pulsar-core/src/pdk/daemon.rs
@@ -12,6 +12,8 @@ pub enum PulsarDaemonError {
     #[error("module {0} not found")]
     ModuleNotFound(String),
     #[error("{0}")]
+    StartError(String),
+    #[error("{0}")]
     StopError(String),
     #[error("error updating the configuration")]
     ConfigurationUpdateError(#[from] anyhow::Error),

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -18,8 +18,9 @@ impl<'a> TryFrom<&'a ModuleConfig> for NoConfig {
     }
 }
 
-/// Trait to implement to create a pulsar pluggable module
-pub trait PulsarModule: Send + Sync {
+/// Trait to implement to create a pulsar pluggable module. Note that this is the fully
+/// featured interface which is often too much. Please see [`BasicPulsarModule`] for a simpler interface.
+pub trait PulsarModule: Send {
     type Config: for<'a> TryFrom<&'a ModuleConfig, Error = ConfigError> + Send + Sync + 'static;
     type State: Send + 'static;
     type ExtraState: Send + 'static;
@@ -68,6 +69,8 @@ pub trait PulsarModule: Send + Sync {
     }
 }
 
+/// A simpler version of [`PulsarModule`] which is often enough. A blanket implementation ensures that
+/// [`PulsarModule`] is implemented for all implementors of [`BasicPulsarModule`].
 pub trait BasicPulsarModule: Send + Sync {
     type Config: for<'a> TryFrom<&'a ModuleConfig, Error = ConfigError> + Send + Sync + 'static;
     type State: Send + 'static;

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -36,7 +36,7 @@ pub trait PulsarModule: Send {
     ) -> impl Future<Output = Result<(Self::State, Self::Extension), ModuleError>> + Send;
 
     fn trigger(
-        state: &mut Self::Extension,
+        extension: &mut Self::Extension,
     ) -> impl Future<Output = Result<Self::TriggerOutput, ModuleError>> + Send;
 
     fn action(
@@ -133,9 +133,7 @@ where
             .map(|v| (v, ()))
     }
 
-    async fn trigger(
-        _extra_state: &mut Self::Extension,
-    ) -> Result<Self::TriggerOutput, ModuleError> {
+    async fn trigger(_extension: &mut Self::Extension) -> Result<Self::TriggerOutput, ModuleError> {
         std::future::pending().await
     }
 

--- a/examples/pulsar-embedded-agent/proxy_module.rs
+++ b/examples/pulsar-embedded-agent/proxy_module.rs
@@ -1,11 +1,11 @@
-use pulsar_core::pdk::{BasicPulsarModule, Event, ModuleContext, ModuleError, NoConfig};
+use pulsar_core::pdk::{Event, ModuleContext, ModuleError, NoConfig, SimplePulsarModule};
 use tokio::sync::mpsc;
 
 pub struct ProxyModule {
     pub tx_proxy: mpsc::Sender<Event>,
 }
 
-impl BasicPulsarModule for ProxyModule {
+impl SimplePulsarModule for ProxyModule {
     type Config = NoConfig;
     type State = ProxyModuleState;
 

--- a/examples/pulsar-embedded-agent/proxy_module.rs
+++ b/examples/pulsar-embedded-agent/proxy_module.rs
@@ -1,28 +1,25 @@
-use pulsar_core::pdk::{Event, ModuleContext, ModuleError, NoConfig, NoExtra, PulsarModule};
+use pulsar_core::pdk::{BasicPulsarModule, Event, ModuleContext, ModuleError, NoConfig};
 use tokio::sync::mpsc;
 
 pub struct ProxyModule {
     pub tx_proxy: mpsc::Sender<Event>,
 }
 
-impl PulsarModule for ProxyModule {
+impl BasicPulsarModule for ProxyModule {
     type Config = NoConfig;
     type State = ProxyModuleState;
-    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "proxy-module";
     const DEFAULT_ENABLED: bool = true;
 
-    fn init_state(
+    async fn init_state(
         &self,
         _config: &Self::Config,
         _ctx: &ModuleContext,
-    ) -> impl futures_util::Future<Output = Result<Self::State, ModuleError>> + Send {
-        async {
-            Ok(Self::State {
-                tx_proxy: self.tx_proxy.clone(),
-            })
-        }
+    ) -> Result<Self::State, ModuleError> {
+        Ok(Self::State {
+            tx_proxy: self.tx_proxy.clone(),
+        })
     }
 
     async fn on_event(

--- a/examples/pulsar-embedded-agent/proxy_module.rs
+++ b/examples/pulsar-embedded-agent/proxy_module.rs
@@ -1,4 +1,4 @@
-use pulsar_core::pdk::{Event, ModuleContext, ModuleError, NoConfig, PulsarModule};
+use pulsar_core::pdk::{Event, ModuleContext, ModuleError, NoConfig, NoExtra, PulsarModule};
 use tokio::sync::mpsc;
 
 pub struct ProxyModule {
@@ -8,6 +8,7 @@ pub struct ProxyModule {
 impl PulsarModule for ProxyModule {
     type Config = NoConfig;
     type State = ProxyModuleState;
+    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "proxy-module";
     const DEFAULT_ENABLED: bool = true;

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -2,25 +2,24 @@
 use std::collections::HashMap;
 
 use pulsar_core::pdk::{
-    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, Payload, PulsarModule,
+    BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, Payload,
 };
 
 pub struct MyCustomModule;
 
-impl PulsarModule for MyCustomModule {
+impl BasicPulsarModule for MyCustomModule {
     type Config = MyModuleConfig;
     type State = MyState;
-    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "my-custom-module";
     const DEFAULT_ENABLED: bool = true;
 
-    fn init_state(
+    async fn init_state(
         &self,
         _config: &Self::Config,
         _ctx: &ModuleContext,
-    ) -> impl futures_util::Future<Output = Result<Self::State, ModuleError>> + Send {
-        async { Ok(Self::State { dns_query_count: 0 }) }
+    ) -> Result<Self::State, ModuleError> {
+        Ok(Self::State { dns_query_count: 0 })
     }
 
     // Handle configuration changes:

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -2,7 +2,7 @@
 use std::collections::HashMap;
 
 use pulsar_core::pdk::{
-    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, Payload, PulsarModule,
+    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, NoExtra, Payload, PulsarModule,
 };
 
 pub struct MyCustomModule;
@@ -10,6 +10,7 @@ pub struct MyCustomModule;
 impl PulsarModule for MyCustomModule {
     type Config = MyModuleConfig;
     type State = MyState;
+    type Extra = NoExtra;
 
     const MODULE_NAME: &'static str = "my-custom-module";
     const DEFAULT_ENABLED: bool = true;

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -2,12 +2,12 @@
 use std::collections::HashMap;
 
 use pulsar_core::pdk::{
-    BasicPulsarModule, ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, Payload,
+    ConfigError, Event, ModuleConfig, ModuleContext, ModuleError, Payload, SimplePulsarModule,
 };
 
 pub struct MyCustomModule;
 
-impl BasicPulsarModule for MyCustomModule {
+impl SimplePulsarModule for MyCustomModule {
     type Config = MyModuleConfig;
     type State = MyState;
 

--- a/src/pulsard/daemon.rs
+++ b/src/pulsard/daemon.rs
@@ -137,7 +137,9 @@ impl PulsarDaemonStarter {
 
             if is_enabled {
                 log::info!("Starting module {module_name}");
-                data.handle.start().await;
+                if let Err(err_msg) = data.handle.start().await {
+                    log::error!("{err_msg}");
+                };
             }
         }
 
@@ -246,8 +248,10 @@ impl PulsarDaemon {
             .get(module_name)
             .ok_or_else(|| PulsarDaemonError::ModuleNotFound(module_name.to_string()))?;
 
-        #[allow(clippy::unit_arg)]
-        Ok(data.handle.start().await)
+        data.handle
+            .start()
+            .await
+            .map_err(PulsarDaemonError::StartError)
     }
 
     /// Restart a module.
@@ -261,8 +265,10 @@ impl PulsarDaemon {
             .await
             .map_err(PulsarDaemonError::StopError)?;
 
-        #[allow(clippy::unit_arg)]
-        Ok(data.handle.start().await)
+        data.handle
+            .start()
+            .await
+            .map_err(PulsarDaemonError::StartError)
     }
 
     /// Stop a module.

--- a/src/pulsard/module_manager.rs
+++ b/src/pulsard/module_manager.rs
@@ -362,7 +362,7 @@ async fn run_module_manager_actor<T: PulsarModule>(mut actor: ModuleManager<T>) 
 async fn run_module_loop<T: PulsarModule>(
     mut config: T::Config,
     mut state: T::State,
-    mut extra_state: T::ExtraState,
+    mut extra_state: T::Extension,
     rx_config: watch::Receiver<ModuleConfig>,
     rx_event: broadcast::Receiver<Arc<Event>>,
     mut rx_shutdown: ShutdownSignal,

--- a/src/pulsard/module_manager.rs
+++ b/src/pulsard/module_manager.rs
@@ -149,7 +149,7 @@ impl<T: PulsarModule> ModuleManager<T> {
                     tx_stop_event_recv,
                 );
 
-                let (state, extra_state) = match self.module.init_state(&module_config, &ctx).await
+                let (state, extension) = match self.module.init_state(&module_config, &ctx).await
                 {
                     Ok(s) => s,
                     Err(err) => {
@@ -175,7 +175,7 @@ impl<T: PulsarModule> ModuleManager<T> {
                     let res = run_module_loop::<T>(
                         module_config,
                         state,
-                        extra_state,
+                        extension,
                         rx_config,
                         rx_event,
                         rx_shutdown,
@@ -362,7 +362,7 @@ async fn run_module_manager_actor<T: PulsarModule>(mut actor: ModuleManager<T>) 
 async fn run_module_loop<T: PulsarModule>(
     mut config: T::Config,
     mut state: T::State,
-    mut extra_state: T::Extension,
+    mut extension: T::Extension,
     rx_config: watch::Receiver<ModuleConfig>,
     rx_event: broadcast::Receiver<Arc<Event>>,
     mut rx_shutdown: ShutdownSignal,
@@ -410,7 +410,7 @@ async fn run_module_loop<T: PulsarModule>(
                 // Drop the Event Receiver and replace it with None
                 rx_event = None
             }
-            t_output = T::trigger(&mut extra_state) => {
+            t_output = T::trigger(&mut extension) => {
                 let t_output = t_output?;
                 T::action(&t_output, &config, &mut state, ctx).await?
             }


### PR DESCRIPTION
Add support for an extra function operating on the state.

The function needs a `trigger` (a `Future`) and an `action` (another `Future`). Under the hood they are used in a `tokio::select!` in the main loop of a module similar to this:

```rust
loop {
  tokio::select! {
   // ...
    out = trigger() => {
      action(out).await;
    }
   // ...
  }
}
```

> **Note:** This is a simplified version of the loop, please refer to the code for more details