### PR TITLE
bundle the installer in the release

### DIFF
--- a/.github/release-assets/pulsar-install.sh
+++ b/.github/release-assets/pulsar-install.sh
@@ -9,11 +9,12 @@
 # It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
 # extension. Note: Most shells limit `local` to 1 var per line, contra bash.
 
-INSTALLER_VERSION=0.1
+# Pulsar version will be inserted by the release workflow
+PULSAR_VERSION=
 
 usage() {
     cat 1>&2 <<EOF
-pulsar-install $INSTALLER_VERSION
+pulsar-install $PULSAR_VERSION
 The installer for pulsar
 USAGE:
     pulsar-install [OPTIONS]
@@ -25,7 +26,7 @@ EOF
 
 version() {
     cat 1>&2 <<EOF
-pulsar-install $INSTALLER_VERSION
+pulsar-install $PULSAR_VERSION
 EOF
 }
 
@@ -96,15 +97,15 @@ main() {
     printf '%s\n' 'info: downloading files' 1>&2
 
     # Download pulsar-exec
-    ensure downloader "https://github.com/Exein-io/pulsar/releases/latest/download/pulsar-exec${_arch}" "${_dir}/pulsar-exec"
+    ensure downloader "https://github.com/exein-io/pulsar/releases/download/${PULSAR_VERSION}/pulsar-exec${_arch}" "${_dir}/pulsar-exec"
 
     # Download release archive
-    local _release_url=$(curl -s https://api.github.com/repos/exein-io/pulsar/releases/latest | grep "tarball_url" | cut -d : -f 2,3 | tr -d , | tr -d \") 
+    local _release_url=$(curl -s https://api.github.com/repos/exein-io/pulsar/releases/tags/${PULSAR_VERSION} | grep "tarball_url" | cut -d : -f 2,3 | tr -d , | tr -d \") 
     local _tmp_pulsar_archive="${_dir}/pulsar.tar.gz"
     ensure downloader $_release_url $_tmp_pulsar_archive
 
     # Extract release archive
-    local _tmp_pulsar_src="${_dir}/pulsar-latest"
+    local _tmp_pulsar_src="${_dir}/pulsar-${PULSAR_VERSION}"
     mkdir -p $_tmp_pulsar_src
     ensure tar -xzf $_tmp_pulsar_archive -C $_tmp_pulsar_src --strip-components=1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,7 +203,7 @@ jobs:
           body: |
             <hr>  
 
-            Check out the [changelog](https://github.com/Exein-io/pulsar/blob/main/CHANGELOG.md) for details on all the changes and fixes.
+            Check out the [changelog](https://github.com/exein-io/pulsar/blob/main/CHANGELOG.md) for details on all the changes and fixes.
 
   docker-push:
     name: Push docker multi-arch image  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,6 +163,12 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@v4
 
+      - name: Create installer
+        run: |
+          installer_blueprint=.github/release-assets/pulsar-install.sh
+
+          sed "s/^PULSAR_VERSION=$/PULSAR_VERSION=${{ env.REGISTRY_TAG }}/" "$installer_blueprint" > /tmp/pulsar-install.sh
+
       - name: Check dev release and tag existence
         if: github.ref_type == 'branch'
         env:
@@ -183,7 +189,7 @@ jobs:
           tag: ${{ env.REGISTRY_TAG }}
           makeLatest: false
           prerelease: true
-          artifacts: "/tmp/binaries/*"
+          artifacts: "/tmp/binaries/*,/tmp/pulsar-install.sh"
           body: 'This is a nightly release based on main branch. Do not use for production'
 
       - name: Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ For the time being to ask questions it is best to open an issue and assigning it
 
 ### Reporting a bug
 
-Before reporting a bug, please take the time to first review [existing bugs](https://github.com/Exein-io/pulsar/issues?q=is%3Aissue+label%3Abug) to avoid creating duplicating issues, causing split discussions. Otherwise, you are free to open a bug report using the [issue template](.github/ISSUE_TEMPLATE/BUG-REPORT.yaml) provided.
+Before reporting a bug, please take the time to first review [existing bugs](https://github.com/exein-io/pulsar/issues?q=is%3Aissue+label%3Abug) to avoid creating duplicating issues, causing split discussions. Otherwise, you are free to open a bug report using the [issue template](.github/ISSUE_TEMPLATE/BUG-REPORT.yaml) provided.
 
 Here are some guidelines for reporting a good bug:
 
@@ -30,7 +30,7 @@ Here are some guidelines for reporting a good bug:
 
 We want to keep improving the project's feature set alongside its existing features. If you have any feedback on how we may achieve that you are more than welcome to create a GitHub issue using the `feature` label! 
 
-> Similar to bug issues, please make sure that the feature or enhancement has not already been requested from the list of [features](https://github.com/Exein-io/pulsar/issues?q=is%3Aissue+label%3Aenhancement).
+> Similar to bug issues, please make sure that the feature or enhancement has not already been requested from the list of [features](https://github.com/exein-io/pulsar/issues?q=is%3Aissue+label%3Aenhancement).
 
 Here are some guidelines for submitting a feature request or enhancement:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ members = [
 version = "0.8.1"
 license = "Apache-2.0 WITH BPF probes exception under GPL-2.0"
 edition = "2021"
-repository = "https://github.com/Exein-io/pulsar"
+repository = "https://github.com/exein-io/pulsar"
 
 [workspace.dependencies]
 # Crates

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pulsar is built with a modular design that makes it easy to adapt the core archi
 To download and install Pulsar, run the following in your terminal:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://github.com/exein-io/pulsar/releases/latest/download/pulsar-install.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/exein-io/pulsar/releases/latest/download/pulsar-install.sh | sh
 ```
 
 Launch the pulsar daemon in a terminal **with administrator privileges**:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pulsar is built with a modular design that makes it easy to adapt the core archi
 To download and install Pulsar, run the following in your terminal:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/exein-io/pulsar/main/pulsar-install.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://github.com/Exein-io/pulsar/releases/latest/download/pulsar-install.sh | sh
 ```
 
 Launch the pulsar daemon in a terminal **with administrator privileges**:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
   <img width="300" src="assets/pulsar-logo-white.png#gh-dark-mode-only" alt="Pulsar light logo">
 
   <p>
-    <a href="https://github.com/Exein-io/pulsar/actions/workflows/release.yaml">
-      <img src="https://github.com/Exein-io/pulsar/actions/workflows/release.yaml/badge.svg?branch=main" alt="Release">
+    <a href="https://github.com/exein-io/pulsar/actions/workflows/release.yaml">
+      <img src="https://github.com/exein-io/pulsar/actions/workflows/release.yaml/badge.svg?branch=main" alt="Release">
     </a>
     <a href="https://discord.gg/ZrySDqhBtZ"><img src="https://img.shields.io/discord/986983233256321075?color=%2331c753&logo=discord">
     <a href="https://opensource.org/licenses/Apache-2.0">
@@ -32,7 +32,7 @@ Pulsar is built with a modular design that makes it easy to adapt the core archi
 To download and install Pulsar, run the following in your terminal:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://github.com/Exein-io/pulsar/releases/latest/download/pulsar-install.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://github.com/exein-io/pulsar/releases/latest/download/pulsar-install.sh | sh
 ```
 
 Launch the pulsar daemon in a terminal **with administrator privileges**:
@@ -75,7 +75,7 @@ The recommended approach to getting started with Pulsar is by using the official
 
 ### Use Pre-built Binaries
 
-Another approach to install Pulsar is by using a pre-built binary. Binaries are available for the [latest release](https://github.com/Exein-io/pulsar/releases/latest). Use `pulsar-exec` for x86-64 (`pulsar-exec-static` for a static build) or `pulsar-exec-static-aarch64` for AArch64 platform. Using there approach you also need to download and setup the [helper scripts](./scripts) to have a more convenient way to start in daemon/cli mode.
+Another approach to install Pulsar is by using a pre-built binary. Binaries are available for the [latest release](https://github.com/exein-io/pulsar/releases/latest). Use `pulsar-exec` for x86-64 (`pulsar-exec-static` for a static build) or `pulsar-exec-static-aarch64` for AArch64 platform. Using there approach you also need to download and setup the [helper scripts](./scripts) to have a more convenient way to start in daemon/cli mode.
 
 ### Build from source
 
@@ -87,7 +87,7 @@ We do not recommend build Pulsar from source. Building from source is only neces
 - [Concepts](https://pulsar.sh/docs/category/concepts): dive deep into Pulsar architecture and main concepts.
 - [Tutorials](https://pulsar.sh/docs/category/tutorials): learn how to use Pulsar with practical examples.
 - [Develop new eBPF modules](https://pulsar.sh/docs/developers/tutorials/create-ebpf-probe-module): build new eBPF probes and integrate them into Pulsar through the modules system;
-- [Roadmap](https://github.com/orgs/Exein-io/projects/14): check out the plan for next Pulsar releases;
+- [Roadmap](https://github.com/orgs/exein-io/projects/14): check out the plan for next Pulsar releases;
 - [Support](https://discord.gg/MQgaTPef7a): join the Discord server for community support.
 
 ## Contributing
@@ -98,7 +98,7 @@ We have a [contributing guide](CONTRIBUTING.md) which will help you getting invo
 
 ## Community
 
-Join the Pulsar [Discord server](https://discord.gg/MQgaTPef7a) to chat with developers, maintainers, and the whole community. You can also drop any question about Pulsar on the official [GitHub discussions](https://github.com/Exein-io/pulsar/discussions) or use the [GitHub issues](https://github.com/Exein-io/pulsar/issues) for feature requests and bug reports.
+Join the Pulsar [Discord server](https://discord.gg/MQgaTPef7a) to chat with developers, maintainers, and the whole community. You can also drop any question about Pulsar on the official [GitHub discussions](https://github.com/exein-io/pulsar/discussions) or use the [GitHub issues](https://github.com/exein-io/pulsar/issues) for feature requests and bug reports.
 
 ## License
 

--- a/crates/bpf-builder/include/compatibility.bpf.h
+++ b/crates/bpf-builder/include/compatibility.bpf.h
@@ -25,7 +25,7 @@
 // will reject the program on an earlier stage.
 //
 // Check these links for more details:
-// https://github.com/Exein-io/pulsar/issues/158
+// https://github.com/exein-io/pulsar/issues/158
 // https://github.com/torvalds/linux/commit/69c087ba6225b574afb6e505b72cb75242a3d844
 
 #ifdef VERSION_5_13

--- a/crates/modules/smtp-notifier/src/template.html.leon
+++ b/crates/modules/smtp-notifier/src/template.html.leon
@@ -52,7 +52,7 @@
 
 <body id="body">
     <img id="logo"
-        src="https://raw.githubusercontent.com/Exein-io/pulsar/07677de701181ed959a9248841dd6d7285be5003/assets/pulsar-logo-white.png"
+        src="https://raw.githubusercontent.com/exein-io/pulsar/07677de701181ed959a9248841dd6d7285be5003/assets/pulsar-logo-white.png"
         alt="Pulsar logo" />
 
     <h2>

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -167,7 +167,7 @@ pub struct ModuleSender {
 
 /// Raises unrecoverable errors from the module to the upper layer.
 ///
-/// Sending an error leads to a graceful shutdown of the module after [issue #7](https://github.com/Exein-io/pulsar/issues/7)
+/// Sending an error leads to a graceful shutdown of the module after [issue #7](https://github.com/exein-io/pulsar/issues/7)
 /// will be closed.
 pub type SignalSender = mpsc::Sender<ModuleSignal>;
 pub type ModuleError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/examples/pulsar-extension-module/README.md
+++ b/examples/pulsar-extension-module/README.md
@@ -30,8 +30,8 @@ We'll add a dependency on the main Pulsar binary and launch it with the custom
 module we wrote.
 
 ```
-pulsar = { git = "https://github.com/Exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
-pulsar-core = { git = "https://github.com/Exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
+pulsar = { git = "https://github.com/exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
+pulsar-core = { git = "https://github.com/exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/examples/pulsar-module-as-library/README.md
+++ b/examples/pulsar-module-as-library/README.md
@@ -21,8 +21,8 @@ it's best to add it as a git dependency. You'll need two more dependencies for
 interacting with pulsar modules: `bpf-common` (eBPF configuration) and tokio.
 
 ```
-network-monitor = { git = "https://github.com/Exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
-bpf-common = { git = "https://github.com/Exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
+network-monitor = { git = "https://github.com/exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
+bpf-common = { git = "https://github.com/exein-io/pulsar", rev = "797f68641ed92b35b152e0d147b9cdcf3bfa49e5" }
 tokio = { version = "1", features = ["full"] }
 ```
 


### PR DESCRIPTION
Fix #185 by adding the installer to every release.

The installer now contains a variable `PULSAR_VERSION` that will be populated by the CI

# Before merge
- [x] manually create and add the installer script to the latest CI to be consistent with the README
