### PR TITLE
feat: Include rootfs in the `Exec` event

### DIFF
--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -96,6 +96,7 @@ pub enum ProcessEvent {
     Exec {
         uid: Uid,
         filename: BufferIndex<str>,
+        rootfs: BufferIndex<str>,
         argc: u32,
         argv: BufferIndex<str>, // 0 separated strings
         namespaces: Namespaces,
@@ -209,6 +210,7 @@ pub mod pulsar {
                         ref argv,
                         namespaces,
                         ref c_container_id,
+                        ..
                     } => {
                         let argv =
                             extract_parameters(argv.bytes(&event.buffer).unwrap_or_else(|err| {
@@ -295,11 +297,13 @@ pub mod pulsar {
                 },
                 ProcessEvent::Exec {
                     filename,
+                    rootfs,
                     argc,
                     argv,
                     ..
                 } => Payload::Exec {
                     filename: filename.string(&buffer)?,
+                    rootfs: rootfs.string(&buffer)?,
                     argc: argc as usize,
                     argv: extract_parameters(argv.bytes(&buffer)?).into(),
                 },

--- a/crates/pulsar-core/src/event.rs
+++ b/crates/pulsar-core/src/event.rs
@@ -211,6 +211,7 @@ pub enum Payload {
     },
     Exec {
         filename: String,
+        rootfs: String,
         argc: usize,
         argv: Argv,
     },
@@ -304,7 +305,7 @@ impl fmt::Display for Payload {
             Payload::FileRename { source, destination } => write!(f,"File Rename {{ source: {source}, destination {destination} }}"),
             Payload::ElfOpened { filename, flags } => write!(f,"Elf Opened {{ filename: {filename}, flags: {flags} }}"),
             Payload::Fork { ppid, uid, gid } => write!(f,"Fork {{ ppid: {ppid} uid: {uid} gid: {gid} }}"),
-            Payload::Exec { filename, argc, argv } => write!(f,"Exec {{ filename: {filename}, argc: {argc}, argv: {argv} }}"),
+            Payload::Exec { filename, rootfs, argc, argv } => write!(f,"Exec {{ filename: {filename}, rootfs: {rootfs}, argc: {argc}, argv: {argv} }}"),
             Payload::Exit { exit_code } => write!(f,"Exit {{ exit_code: {exit_code} }}"),
             Payload::ChangeParent { ppid } => write!(f,"Parent changed {{ ppid: {ppid} }}"),
             Payload::CredentialsChange { uid, gid } => write!(f,"Credentials changed {{ uid: {uid} gid: {gid} }}"),


### PR DESCRIPTION
`image` field of the `Exec` event is relative to the root filesystem of the process. That makes it hard to determine the location of the binary if the process is containerized (or, in general, runs inside a mount namespace).

That's where the new `rootfs` comes with help. It contains the full path to the root filesystem, which in case of containers has format like:

```
/root/var/lib/docker/btrfs/subvolumes/0991d46b6f686f22f06bddb6948073[...]
```

Using that information, we can still inspect that container layer even when the process (or even container) are not running anymore.

# Pull Request Title

_Short introduction explaining the motivation and reasoning behind the pull request._

## Implementation (Optional)

_Feel free to include design and implementation for external review outside of the code changes._

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
