### PR TITLE
ci: Call `apt-get update` before installing any packages

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: Install dependencies
         if: endsWith(matrix.platform.target, 'musl')
         run: |
-          sudo apt install -y qemu-system
+          sudo apt-get update
+          sudo apt-get install -y qemu-system
 
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
We noticed CI failures related to lack of ability to fetch packages. Refreshing the repository metadata with `apt-get update` should fix that.
