### PR TITLE
fix: Docker container ID parsing with cgroupfs driver

### DIFF
--- a/crates/bpf-builder/include/buffer.bpf.h
+++ b/crates/bpf-builder/include/buffer.bpf.h
@@ -60,7 +60,9 @@ static void buffer_index_init(struct buffer *buffer,
   index->len = 0;
 }
 
-// Copy up to len bytes from source to the buffer pointed by index.
+// Copies up to @len bytes from @source, starting from the given @offset, to
+// the @buffer pointed by @index.
+//
 // On success, update index and buffer length. Source is treated as a string:
 // the copy will be interrupted when encountering a NULL byte.
 static __always_inline void buffer_append_str(struct buffer *buffer,

--- a/crates/bpf-builder/include/get_path.bpf.h
+++ b/crates/bpf-builder/include/get_path.bpf.h
@@ -142,8 +142,8 @@ static __always_inline long loop_append_path_component(u32 i,
     return LOOP_STOP;
   char *name = (char *)c->components->component_name[t];
   int len = c->components->component_len[t];
-  buffer_append_str(c->buffer, c->index, "/", 1);
-  buffer_append_str(c->buffer, c->index, name, len);
+  buffer_append_str(c->buffer, c->index, "/", 1, 0);
+  buffer_append_str(c->buffer, c->index, name, len, 0);
   return LOOP_CONTINUE;
 }
 

--- a/crates/modules/file-system-monitor/probes.bpf.c
+++ b/crates/modules/file-system-monitor/probes.bpf.c
@@ -135,7 +135,7 @@ static __always_inline void on_path_symlink(void *ctx, struct path *dir,
   get_path_str(&path, &event->buffer, &event->link.source);
   buffer_index_init(&event->buffer, &event->link.destination);
   buffer_append_str(&event->buffer, &event->link.destination, old_name,
-                    BUFFER_MAX);
+                    BUFFER_MAX, 0);
   event->link.hard_link = false;
   output_fs_event(ctx, event);
 }

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -162,20 +162,18 @@ struct container_id_buffer
 
 /*
 Identifies the container engine and reads the cgroup id of a process
-from its `task_struct` into an given array of character.
+from its `task_struct` into a given `container_id_buffer`.
 
 ### Input:
-    `char buf[]`: a pointer to an array of characters
-    `size_t sz`: size of the buffer
-    `int *offset`: a pointer to an integer
     `struct task_struct *cur_tsk`: a pointer to a process task struct
+    `struct container_id_buffer *c_id_buf`: a pointer to the buffer
 
 ### Success:
     the return value is:
       - `0`: it's a docker container id
       - `1`: it's a podman container id
-    and the characters array `buf` contains the id of the container
-    at the position specified in the value pointed by `offset`.
+    and `c_id_buf->buf` contains the id of the container at the position
+    specified in the value pointed by `c_id_buf->offset`.
 
 ### Error:
     if return value is less than `0`, in particular:
@@ -189,7 +187,8 @@ from its `task_struct` into an given array of character.
               of the process after a successful parse of a `container`
               cgroup name for the given process
 */
-static __always_inline int get_container_info(struct task_struct *cur_tsk, struct container_id_buffer *c_id_buf)
+static __always_inline int get_container_info(struct task_struct *cur_tsk,
+                                              struct container_id_buffer *c_id_buf)
 {
   int cgrp_id;
   struct container_id_buffer parent_buf;

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -157,7 +157,7 @@ Buffer for reading container id of a process. The Container ID is located at `bu
 struct container_id_buffer
 {
   char buf[CONTAINER_ID_MAX_BUF];
-  int offset;
+  size_t offset;
 };
 
 /*
@@ -332,7 +332,7 @@ int BPF_PROG(sched_process_fork, struct task_struct *parent,
     event->fork.option_index.container_id.container_engine = container_engine;
     buffer_index_init(&event->buffer, &event->fork.option_index.container_id.cgroup_id);
     buffer_append_str(&event->buffer, &event->fork.option_index.container_id.cgroup_id,
-                      c_id_buf.buf + c_id_buf.offset, CONTAINER_ID_MAX_BUF);
+                      c_id_buf.buf, CONTAINER_ID_MAX_BUF, c_id_buf.offset);
 
     LOG_DEBUG("fork - detected container with id: %s", c_id_buf.buf + c_id_buf.offset);
   }
@@ -378,7 +378,7 @@ int BPF_PROG(sched_process_exec, struct task_struct *p, pid_t old_pid,
     event->exec.option_index.container_id.container_engine = container_engine;
     buffer_index_init(&event->buffer, &event->exec.option_index.container_id.cgroup_id);
     buffer_append_str(&event->buffer, &event->exec.option_index.container_id.cgroup_id,
-                      c_id_buf.buf + c_id_buf.offset, CONTAINER_ID_MAX_BUF);
+                      c_id_buf.buf, CONTAINER_ID_MAX_BUF, c_id_buf.offset);
 
     LOG_DEBUG("exec - detected container with id: %s", c_id_buf.buf + c_id_buf.offset);
   }
@@ -409,7 +409,7 @@ int BPF_PROG(sched_process_exec, struct task_struct *p, pid_t old_pid,
   {
     buffer_index_init(&event->buffer, &event->exec.filename);
     buffer_append_str(&event->buffer, &event->exec.filename, bprm_filename,
-                      BUFFER_MAX);
+                      BUFFER_MAX, 0);
   }
   else
   {
@@ -621,7 +621,7 @@ int BPF_PROG(cgroup_mkdir, struct cgroup *cgrp, const char *path)
   event->cgroup_mkdir.id = BPF_CORE_READ(cgrp, kn, id);
   buffer_index_init(&event->buffer, &event->cgroup_mkdir.path);
   buffer_append_str(&event->buffer, &event->cgroup_mkdir.path, path,
-                    BUFFER_MAX);
+                    BUFFER_MAX, 0);
   output_process_event(ctx, event);
   return 0;
 }
@@ -638,7 +638,7 @@ int BPF_PROG(cgroup_rmdir, struct cgroup *cgrp, const char *path)
   event->cgroup_rmdir.id = BPF_CORE_READ(cgrp, kn, id);
   buffer_index_init(&event->buffer, &event->cgroup_rmdir.path);
   buffer_append_str(&event->buffer, &event->cgroup_rmdir.path, path,
-                    BUFFER_MAX);
+                    BUFFER_MAX, 0);
   output_process_event(ctx, event);
   return 0;
 }
@@ -660,7 +660,7 @@ int BPF_PROG(cgroup_attach_task, struct cgroup *cgrp, const char *path,
   event->cgroup_attach.pid = BPF_CORE_READ(task, tgid);
   buffer_index_init(&event->buffer, &event->cgroup_attach.path);
   buffer_append_str(&event->buffer, &event->cgroup_attach.path, path,
-                    BUFFER_MAX);
+                    BUFFER_MAX, 0);
   output_process_event(ctx, event);
   return 0;
 }


### PR DESCRIPTION
The format of cgroup path is different for systemd and cgroupfs drivers.

For systemd driver, it's

```
0::/system.slice/docker-d4ea646fc22c701dbb146e52db4e9125dcca2eebb2f5552f90fedbb28a0f0716.scope
```

For cgroupfs driver, it's

```
0::/docker/2cf2e0be458a80acb354c953f7bb03de5d2d277dfcb8ebaa6575f95668a0c15f
```

Handle both formats.
