### PR TITLE
chore: improve func autodetect error message

### DIFF
--- a/crates/bpf-feature-autodetect/src/lib.rs
+++ b/crates/bpf-feature-autodetect/src/lib.rs
@@ -30,10 +30,12 @@ pub fn autodetect_features() -> BpfFeatures {
     BpfFeatures {
         atomics: atomics_supported(),
         cgroup_skb_task_btf: func_id_supported(
+            "bpf_get_current_task_btf",
             bpf_func_id::BPF_FUNC_get_current_task_btf,
             BpfProgType::BPF_PROG_TYPE_CGROUP_SKB,
         ),
         bpf_loop: func_id_supported(
+            "bpf_loop",
             bpf_func_id::BPF_FUNC_loop,
             // Program type doesn't matter here.
             BpfProgType::BPF_PROG_TYPE_KPROBE,


### PR DESCRIPTION
in case of  errors in function probing `feature_autodetect` is showing a message like this:
```console
[2024-06-18T12:43:03Z WARN  bpf_feature_autodetect::func] Function 181 in program type BPF_PROG_TYPE_KPROBE not supported: Failed to load the eBPF feature probe: 0: R1=ctx(off=0,imm=0) R10=fp0
    0: (85) call bpf_loop#181
    R2 !read_ok
    processed 1 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
``` 

this pr wants to reduce the output if backtrace is not enabled limiting the warning to one line
