### PR TITLE
ci: Run workflows on all pull requests, not only the ones to `main` branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build
 on:
   pull_request:
     branches:
-      - main
+      - "*"
 
 jobs:
   build:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,7 +2,7 @@ name: Integration tests
 on:
   pull_request:
     branches:
-      - main
+      - "*"
 
 jobs:
   integration-tests:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -2,7 +2,7 @@ name: Quality Checks
 on:
   pull_request:
     branches:
-      - main
+      - "*"
 
 jobs:
   lychee-link-check:


### PR DESCRIPTION
We are often making pull requests to branches other than `main`. In such case, before this change, we weren't sure whether such "stacked PRs" are passing the CI tests.