### PR TITLE
fix(network-monitor): Include the packet payload regarless of L4 protocol

### DIFF
--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -557,10 +557,6 @@ pub mod test_suite {
         // for TCP it's overriden on connection
         let mut source = dest;
         let msg = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        let data_copied = match proto {
-            Proto::TCP => Vec::new(),
-            Proto::UDP => msg.to_vec(),
-        };
         TestRunner::with_ebpf(program)
             .run(|| match proto {
                 Proto::UDP => {
@@ -592,7 +588,7 @@ pub mod test_suite {
                 NetworkEvent::Send,
                 (dst, dest.into(), "destination address"),
                 (src, source.into(), "source address"),
-                (data, data_copied.clone(), "data copy"),
+                (data, msg.to_vec(), "data copy"),
                 (data_len, msg.len() as u32, "real message len"),
                 (proto, proto, "protocol")
             ))
@@ -600,7 +596,7 @@ pub mod test_suite {
                 NetworkEvent::Receive,
                 (dst, source.into(), "destination address"),
                 (src, dest.into(), "source address"),
-                (data, data_copied.clone(), "data copy"),
+                (data, msg.to_vec(), "data copy"),
                 (data_len, msg.len() as u32, "real message len"),
                 (proto, proto, "protocol")
             ))

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -303,11 +303,11 @@ pub mod pulsar {
         let data = data
             .bytes(&event.buffer)
             .map_err(|err| {
-                log::error!("[dns] Error getting message: {}", err);
+                log::error!("Error getting network packet payload: {err}");
             })
             .ok()?;
 
-        // any valid dns data?
+        // Check wheter the payload contains any DNS data.
         let dns = dns_parser::Packet::parse(data).ok()?;
         let with_q = !dns.questions.is_empty();
         let with_a = !dns.answers.is_empty();


### PR DESCRIPTION
* User-space part of pulsar is expecting the buffer to be initialized regardless of L4 protocol (TCP or UDP).
* DNS responses, if long enough, might go through TCP. Not very common, but possible.
* Stop returning an error when packet payload length is 0. It's totally normal for SYN, SYN-ACK and ACK packets. Logging errors for them is an unnecessary noise.

Fixes #297
