### PR TITLE
threat logger module rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,18 +1668,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "logger"
-version = "0.8.1"
-dependencies = [
- "bpf-common",
- "log",
- "pulsar-core",
- "serde_json",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,7 +2175,6 @@ dependencies = [
  "file-system-monitor",
  "futures-util",
  "log",
- "logger",
  "network-monitor",
  "nix 0.27.1",
  "process-monitor",
@@ -2197,6 +2184,7 @@ dependencies = [
  "semver",
  "serde",
  "smtp-notifier",
+ "threat-logger",
  "tokio",
 ]
 
@@ -2935,6 +2923,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "threat-logger"
+version = "0.8.1"
+dependencies = [
+ "bpf-common",
+ "log",
+ "pulsar-core",
+ "serde_json",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pulsar-core = { workspace = true }
 # Modules
 desktop-notifier = { workspace = true, optional = true }
 file-system-monitor = { workspace = true, optional = true }
-logger = { workspace = true, optional = true }
+threat-logger = { workspace = true, optional = true }
 network-monitor = { workspace = true, optional = true }
 process-monitor = { workspace = true, optional = true }
 rules-engine = { workspace = true, optional = true }
@@ -42,7 +42,7 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = ["full", "tls-openssl"]
 full = ["core", "extra"]
-core = ["logger", "process-monitor", "network-monitor", "file-system-monitor"]
+core = ["threat-logger", "process-monitor", "network-monitor", "file-system-monitor"]
 extra = ["rules-engine", "desktop-notifier", "smtp-notifier"]
 tls-openssl = ["smtp-notifier/tls-openssl"]
 tls-rustls = ["smtp-notifier/tls-rustls"]
@@ -56,7 +56,7 @@ members = [
     "crates/modules/process-monitor",
     "crates/modules/network-monitor",
     "crates/modules/rules-engine",
-    "crates/modules/logger",
+    "crates/modules/threat-logger",
     "crates/modules/desktop-notifier",
     "crates/modules/smtp-notifier",
     "crates/pulsar-core",
@@ -98,7 +98,7 @@ desktop-notifier = { path = "crates/modules/desktop-notifier" }
 file-system-monitor = { path = "crates/modules/file-system-monitor", features = [
     "test-suite",
 ] }
-logger = { path = "crates/modules/logger" }
+threat-logger = { path = "crates/modules/threat-logger" }
 network-monitor = { path = "crates/modules/network-monitor", features = [
     "test-suite",
 ] }

--- a/crates/modules/README.md
+++ b/crates/modules/README.md
@@ -5,4 +5,4 @@
 | `process-monitor` | Producer | Watch processes (fork/exec/exit)
 | `file-system-monitor` | Producer | Watch file system events
 | `network-monitor` | Producer | Watch network events
-| `logger` | Consumer | Log events to stdout. Used for development and toubleshooting
+| `threat-logger` | Consumer | Log events to stdout. Used for development and toubleshooting

--- a/crates/modules/threat-logger/Cargo.toml
+++ b/crates/modules/threat-logger/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "logger"
+name = "threat-logger"
 version.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/modules/threat-logger/README.md
+++ b/crates/modules/threat-logger/README.md
@@ -23,5 +23,5 @@ output_format=plaintext
 You disable this module with:
 
 ```sh
-pulsar config --set logger.enabled=false
+pulsar config --set threat-logger.enabled=false
 ```

--- a/crates/modules/threat-logger/README.md
+++ b/crates/modules/threat-logger/README.md
@@ -1,4 +1,4 @@
-# Logger
+# Threat logger
 
 This module will log Pulsar threat events to stdout.
 
@@ -13,7 +13,7 @@ This module will log Pulsar threat events to stdout.
 Default configuration:
 
 ```ini
-[logger]
+[threat-logger]
 enabled=true
 console=true
 syslog=true

--- a/src/pulsard/mod.rs
+++ b/src/pulsard/mod.rs
@@ -47,8 +47,8 @@ pub async fn pulsar_daemon_run(
     starter.add_module(file_system_monitor::pulsar::FileSystemMonitorModule)?;
     #[cfg(feature = "network-monitor")]
     starter.add_module(network_monitor::pulsar::NetworkMonitorModule)?;
-    #[cfg(feature = "logger")]
-    starter.add_module(logger::LoggerModule)?;
+    #[cfg(feature = "threat-logger")]
+    starter.add_module(threat_logger::ThreatLoggerModule)?;
     #[cfg(feature = "rules-engine")]
     starter.add_module(rules_engine::RuleEngineModule)?;
     #[cfg(feature = "desktop-notifier")]


### PR DESCRIPTION
Fixes #310 renaming `logger` to `threat-logger` in a consistent way