### PR TITLE
Improve error handling in engine_api client using thiserror. Fixes #326

### DIFF
--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -83,7 +83,7 @@ impl EngineApiClient {
             .client
             .request(req)
             .await
-            .map_err(|err| EngineClientError::HyperClientError(err))?;
+            .map_err(EngineClientError::HyperClientError)?;
 
         let status = res.status();
 
@@ -261,7 +261,7 @@ impl EngineApiClient {
         let (_, read_stream) = ws_stream.split();
 
         let events_stream = read_stream.map(|item| {
-            item.map_err(|err| WebsocketError::from_tungstenite_error(err))
+            item.map_err(WebsocketError::from_tungstenite_error)
                 .and_then(|msg| {
                     if let Message::Text(json) = msg {
                         let event: Event =

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -54,7 +54,7 @@ impl EngineApiClient {
         // Check for write permission on socket
         let cstring = match CString::new(socket.as_str()) {
             Ok(cs) => cs,
-            Err(err) => return Err(EngineClientError::CStringConversion(err.to_string())),
+            Err(err) => return Err(EngineClientError::CStringConversion(err)),
         };
 
         let write_permission = unsafe { libc::access(cstring.as_ptr(), libc::W_OK) } == 0;

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -235,9 +235,7 @@ impl EngineApiClient {
     ) -> Result<impl Stream<Item = Result<Event, WebsocketError>>, EngineClientError> {
         let stream = tokio::net::UnixStream::connect(&self.socket)
             .await
-            .map_err(|err| {
-                EngineClientError::IoError(format!("Failed to connect to socket: {}", err))
-            })?;
+            .map_err(EngineClientError::SocketConnectionError)?;
 
         // The `localhost` domain is simply a placeholder for the url. It's not used because is already present a stream
         let (ws_stream, _) = client_async("ws://localhost/monitor", stream)

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -171,13 +171,13 @@ impl EngineApiClient {
             .uri(url)
             .header("content-type", "application/json")
             .body(Either::Left(Full::from(body_string)))
-            .map_err(EngineClientError::HttpError)?;
+            .map_err(EngineClientError::RequestBuilderError)?;
 
         let res = self
             .client
             .request(req)
             .await
-            .map_err(|err| EngineClientError::HyperRequestError(err.to_string()))?;
+            .map_err(EngineClientError::HyperClientError)?;
 
         let status = res.status();
 
@@ -210,7 +210,7 @@ impl EngineApiClient {
             .method(Method::POST)
             .uri(uri)
             .body(Either::Right(Empty::<Bytes>::new()))
-            .map_err(EngineClientError::HttpError)?;
+            .map_err(EngineClientError::RequestBuilderError)?;
 
         let res = self
             .client

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -77,7 +77,7 @@ impl EngineApiClient {
             .method(Method::GET)
             .uri(uri)
             .body(Either::Right(Empty::<Bytes>::new()))
-            .map_err(EngineClientError::HttpError)?;
+            .map_err(EngineClientError::RequestBuilderError)?;
 
         let res = self
             .client

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -33,17 +33,15 @@ impl EngineApiClient {
 
         // Check if input exists and if it is a unix socket
         match std::fs::metadata(&socket) {
-            Err(err) => return match err.kind() {
-                std::io::ErrorKind::NotFound => {
-                    Err(EngineClientError::SocketNotFound(socket))
-                }
-                std::io::ErrorKind::PermissionDenied => {
-                    Err(EngineClientError::NoReadPermission(socket))
-                }
-                _ => {
-                    Err(EngineClientError::FailedToGetMetadata(socket))
-                }
-            },
+            Err(err) => {
+                return match err.kind() {
+                    std::io::ErrorKind::NotFound => Err(EngineClientError::SocketNotFound(socket)),
+                    std::io::ErrorKind::PermissionDenied => {
+                        Err(EngineClientError::NoReadPermission(socket))
+                    }
+                    _ => Err(EngineClientError::FailedToGetMetadata(socket)),
+                };
+            }
             Ok(metadata) => {
                 if !metadata.file_type().is_socket() {
                     return Err(EngineClientError::NotASocket(socket));

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -92,7 +92,7 @@ impl EngineApiClient {
                 let buf = res
                     .collect()
                     .await
-                    .map_err(|err| EngineClientError::HyperRequestError(err.to_string()))?
+                    .map_err(EngineClientError::hyper_request_error)?
                     .aggregate();
 
                 let output = serde_json::from_reader(buf.reader())
@@ -104,7 +104,7 @@ impl EngineApiClient {
                 let error = res
                     .collect()
                     .await
-                    .map_err(|err| EngineClientError::HyperRequestError(err.to_string()))?
+                    .map_err(EngineClientError::hyper_request_error)?
                     .to_bytes();
 
                 let error_str = std::str::from_utf8(&error)
@@ -188,17 +188,15 @@ impl EngineApiClient {
                     .collect()
                     .await
                     .map_err(|err| {
-                        EngineClientError::HyperRequestError(format!(
+                        EngineClientError::hyper_request_error(format!(
                             "Error collecting response: {}",
                             err
                         ))
                     })?
                     .to_bytes();
 
-                let error_str = match std::str::from_utf8(&error) {
-                    Ok(s) => s,
-                    Err(err) => return Err(EngineClientError::Utf8Error(err.to_string())),
-                };
+                let error_str = std::str::from_utf8(&error)
+                    .map_err(|err| EngineClientError::Utf8Error(err.to_string()))?;
 
                 Err(EngineClientError::UnexpectedResponse(error_str.to_string()))
             }
@@ -216,7 +214,7 @@ impl EngineApiClient {
             .client
             .request(req)
             .await
-            .map_err(|err| EngineClientError::HyperRequestError(err.to_string()))?;
+            .map_err(EngineClientError::HyperClientError)?;
 
         let status = res.status();
 
@@ -227,17 +225,15 @@ impl EngineApiClient {
                     .collect()
                     .await
                     .map_err(|err| {
-                        EngineClientError::HyperRequestError(format!(
+                        EngineClientError::hyper_request_error(format!(
                             "Error collecting response: {}",
                             err
                         ))
                     })?
                     .to_bytes();
 
-                let error_str = match std::str::from_utf8(&error) {
-                    Ok(s) => s,
-                    Err(err) => return Err(EngineClientError::Utf8Error(err.to_string())),
-                };
+                let error_str = std::str::from_utf8(&error)
+                    .map_err(|err| EngineClientError::Utf8Error(err.to_string()))?;
 
                 Err(EngineClientError::UnexpectedResponse(error_str.to_string()))
             }

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -92,7 +92,7 @@ impl EngineApiClient {
                 let buf = res
                     .collect()
                     .await
-                    .map_err(|err| EngineClientError::CollectResponseError(err.to_string()))?
+                    .map_err(EngineClientError::CollectResponseError)?
                     .aggregate();
 
                 let output = serde_json::from_reader(buf.reader())
@@ -104,7 +104,7 @@ impl EngineApiClient {
                 let error = res
                     .collect()
                     .await
-                    .map_err(|err| EngineClientError::CollectResponseError(err.to_string()))?
+                    .map_err(EngineClientError::CollectResponseError)?
                     .to_bytes();
 
                 let error_str =
@@ -187,7 +187,7 @@ impl EngineApiClient {
                 let error = res
                     .collect()
                     .await
-                    .map_err(|err| EngineClientError::CollectResponseError(err.to_string()))?
+                    .map_err(EngineClientError::CollectResponseError)?
                     .to_bytes();
 
                 let error_str =
@@ -219,7 +219,7 @@ impl EngineApiClient {
                 let error = res
                     .collect()
                     .await
-                    .map_err(|err| EngineClientError::CollectResponseError(err.to_string()))?
+                    .map_err(EngineClientError::CollectResponseError)?
                     .to_bytes();
 
                 let error_str =

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -33,15 +33,15 @@ impl EngineApiClient {
 
         // Check if input exists and if it is a unix socket
         match std::fs::metadata(&socket) {
-            Err(err) => match err.kind() {
+            Err(err) => return match err.kind() {
                 std::io::ErrorKind::NotFound => {
-                    return Err(EngineClientError::SocketNotFound(socket));
+                    Err(EngineClientError::SocketNotFound(socket))
                 }
                 std::io::ErrorKind::PermissionDenied => {
-                    return Err(EngineClientError::NoReadPermission(socket));
+                    Err(EngineClientError::NoReadPermission(socket))
                 }
                 _ => {
-                    return Err(EngineClientError::FailedToGetMetadata(socket));
+                    Err(EngineClientError::FailedToGetMetadata(socket))
                 }
             },
             Ok(metadata) => {

--- a/crates/engine-api/src/client.rs
+++ b/crates/engine-api/src/client.rs
@@ -78,7 +78,7 @@ impl EngineApiClient {
             .method(Method::GET)
             .uri(uri)
             .body(Either::Right(Empty::<Bytes>::new()))
-            .map_err(|e| EngineClientError::HttpError(e))?;
+            .map_err(EngineClientError::HttpError)?;
 
         let res = self
             .client
@@ -150,7 +150,7 @@ impl EngineApiClient {
             .uri(url)
             .header("content-type", "application/json")
             .body(Either::Left(Full::from(body_string)))
-            .map_err(|e| EngineClientError::HttpError(e))?;
+            .map_err(EngineClientError::HttpError)?;
 
         let res = self
             .client
@@ -189,7 +189,7 @@ impl EngineApiClient {
             .method(Method::POST)
             .uri(uri)
             .body(Either::Right(Empty::<Bytes>::new()))
-            .map_err(|e| EngineClientError::HttpError(e))?;
+            .map_err(EngineClientError::HttpError)?;
 
         let res = self
             .client

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -37,15 +37,15 @@ pub enum EngineClientError {
 
     /// C string conversion error
     #[error("C string conversion error: {0}")]
-    CStringConversion(String),
+    CStringConversion(#[from] std::ffi::NulError),
 
     /// Hyper error
     #[error("Hyper client error: {0}")]
-    HyperError(#[from] hyper_util::client::legacy::Error),
+    HyperError(#[from] hyper_util::client::legacy::Error), // For client.request() errors
 
     /// Collect Response Error
     #[error("Error collecting response: {0}")]
-    CollectResponseError(#[from] hyper::Error),
+    CollectResponseError(#[from] hyper::Error), // For res.collect() errors
 
     /// Error during request building
     #[error("Failed to build request: {0}")]

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -67,9 +67,9 @@ pub enum EngineClientError {
     #[error("Unexpected response: {0}")]
     UnexpectedResponse(String),
 
-    /// I/O error
-    #[error("I/O error: {0}")]
-    IoError(String),
+    /// Socket connection error
+    #[error("Failed to connect to socket: {0}")]
+    SocketConnectionError(#[from] std::io::Error),
 
     /// WebSocket error
     #[error("WebSocket error: {0}")]

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
 
 use axum::{http::StatusCode, response::IntoResponse};
+use hyper::http;
 use pulsar_core::pdk::PulsarDaemonError;
 use thiserror::Error;
+use tokio::io;
 
 #[derive(Debug)]
 pub enum EngineApiError {
@@ -11,13 +13,116 @@ pub enum EngineApiError {
     ServiceUnavailable,
 }
 
+/// Error types for the Engine API client
+#[derive(Debug, Error)]
+pub enum EngineClientError {
+    /// Socket not found
+    #[error("Unix socket not found: {0}")]
+    SocketNotFound(String),
+    
+    /// Failed to get metadata
+    #[error("Failed to get metadata: {0}")]
+    FailedToGetMetadata(String),
+    
+    /// No write permission
+    #[error("No write permission: {0}")]
+    NoWritePermission(String),
+    
+    /// Not a unix socket
+    #[error("Not a unix socket: {0}")]
+    NotASocket(String),
+    
+    /// C string conversion error
+    #[error("C string conversion error: {0}")]
+    CStringConversion(String),
+    
+    /// Hyper request error
+    #[error("Hyper request error: {0}")]
+    HyperRequest(String),
+    
+    /// HTTP error
+    #[error("HTTP error: {0}")]
+    HttpError(#[from] http::Error),
+    
+    /// Serialization error
+    #[error("Serialization error: {0}")]
+    SerializeError(String),
+    
+    /// Deserialization error
+    #[error("Deserialization error: {0}")]
+    DeserializeError(String),
+    
+    /// UTF-8 error
+    #[error("UTF-8 error: {0}")]
+    Utf8Error(String),
+    
+    /// Unexpected response
+    #[error("Unexpected response: {0}")]
+    UnexpectedResponse(String),
+    
+    /// I/O error
+    #[error("I/O error: {0}")]
+    IoError(String),
+    
+    /// WebSocket error
+    #[error("WebSocket error: {0}")]
+    WebSocketError(String),
+    
+    /// Unknown error
+    #[error("Unknown error: {0}")]
+    Other(String),
+}
+
+impl From<std::ffi::NulError> for EngineClientError {
+    fn from(err: std::ffi::NulError) -> Self {
+        Self::CStringConversion(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for EngineClientError {
+    fn from(err: serde_json::Error) -> Self {
+        match err.classify() {
+            serde_json::error::Category::Io => {
+                Self::SerializeError(format!("IO error during serialization: {}", err))
+            }
+            serde_json::error::Category::Syntax => {
+                Self::DeserializeError(format!("JSON syntax error: {}", err))
+            }
+            serde_json::error::Category::Data => {
+                Self::DeserializeError(format!("JSON data error: {}", err))
+            }
+            serde_json::error::Category::Eof => {
+                Self::DeserializeError(format!("Unexpected end of JSON input: {}", err))
+            }
+        }
+    }
+}
+
+impl From<std::str::Utf8Error> for EngineClientError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8Error(err.to_string())
+    }
+}
+
+impl From<io::Error> for EngineClientError {
+    fn from(err: io::Error) -> Self {
+        Self::IoError(err.to_string())
+    }
+}
+
+/// WebSocket related errors
 #[derive(Debug, Error)]
 pub enum WebsocketError {
-    #[error(transparent)]
+    /// JSON error
+    #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
-    #[error(transparent)]
+    
+    /// Connection error
+    #[error("Connection error: {0}")]
     ConnectionError(#[from] tokio_tungstenite::tungstenite::Error),
-    #[error("unsupported message type")]
+    
+    /// Unsupported message type
+    #[error("Unsupported message type")]
     UnsupportedMessageType,
 }
 
@@ -60,5 +165,12 @@ impl From<PulsarDaemonError> for EngineApiError {
                 Self::InternalServerError
             }
         }
+    }
+}
+
+// Implement From<EngineClientError> for anyhow::Error to allow easy conversion
+impl From<EngineClientError> for anyhow::Error {
+    fn from(err: EngineClientError) -> Self {
+        anyhow::anyhow!(err.to_string())
     }
 }

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -167,10 +167,3 @@ impl From<PulsarDaemonError> for EngineApiError {
         }
     }
 }
-
-// Implement From<EngineClientError> for anyhow::Error to allow easy conversion
-impl From<EngineClientError> for anyhow::Error {
-    fn from(err: EngineClientError) -> Self {
-        anyhow::anyhow!(err.to_string())
-    }
-}

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -45,11 +45,11 @@ pub enum EngineClientError {
 
     /// Collect Response Error
     #[error("Error collecting response: {0}")]
-    CollectResponseError(String),
+    CollectResponseError(#[from] hyper::Error),
 
     /// Error during request building
     #[error("Failed to build request: {0}")]
-    RequestBuilderError(http::Error),
+    RequestBuilderError(#[from] http::Error),
 
     /// Serialization error
     #[error("Serialization error: {0}")]

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -112,12 +112,7 @@ pub enum WebsocketError {
 
     /// Connection error
     #[error("WebSocket connection error: {0}")]
-    ConnectionError(String),
-}
-impl From<tokio_tungstenite::tungstenite::Error> for WebsocketError {
-    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
-        WebsocketError::ConnectionError(err.to_string())
-    }
+    ConnectionError(#[from] tokio_tungstenite::tungstenite::Error),
 }
 
 impl Display for EngineApiError {

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -69,7 +69,7 @@ pub enum EngineClientError {
 
     /// Socket connection error
     #[error("Failed to connect to socket: {0}")]
-    SocketConnectionError(#[from] std::io::Error),
+    SocketConnectionError(std::io::Error),
 
     /// WebSocket error
     #[error("WebSocket error: {0}")]

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -45,11 +45,11 @@ pub enum EngineClientError {
 
     /// Collect Response Error
     #[error("Error collecting response: {0}")]
-    CollectResponseError(#[from] hyper::Error), // For res.collect() errors
+    CollectResponseError(hyper::Error), // For res.collect() errors
 
     /// Error during request building
     #[error("Failed to build request: {0}")]
-    RequestBuilderError(#[from] http::Error),
+    RequestBuilderError(http::Error),
 
     /// Serialization error
     #[error("Serialization error: {0}")]

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -127,7 +127,12 @@ impl EngineClientError {
     pub fn request_builder_error(err: http::Error) -> Self {
         Self::RequestBuilderError(err)
     }
+
+    pub fn hyper_request_error<E: std::fmt::Display>(err: E) -> Self {
+        Self::HyperRequestError(err.to_string())
+    }
 }
+
 /// WebSocket related errors
 #[derive(Debug, Error)]
 pub enum WebsocketError {

--- a/crates/engine-api/src/error.rs
+++ b/crates/engine-api/src/error.rs
@@ -19,55 +19,55 @@ pub enum EngineClientError {
     /// Socket not found
     #[error("Unix socket not found: {0}")]
     SocketNotFound(String),
-    
+
     /// Failed to get metadata
     #[error("Failed to get metadata: {0}")]
     FailedToGetMetadata(String),
-    
+
     /// No write permission
     #[error("No write permission: {0}")]
     NoWritePermission(String),
-    
+
     /// Not a unix socket
     #[error("Not a unix socket: {0}")]
     NotASocket(String),
-    
+
     /// C string conversion error
     #[error("C string conversion error: {0}")]
     CStringConversion(String),
-    
+
     /// Hyper request error
     #[error("Hyper request error: {0}")]
     HyperRequest(String),
-    
+
     /// HTTP error
     #[error("HTTP error: {0}")]
     HttpError(#[from] http::Error),
-    
+
     /// Serialization error
     #[error("Serialization error: {0}")]
     SerializeError(String),
-    
+
     /// Deserialization error
     #[error("Deserialization error: {0}")]
     DeserializeError(String),
-    
+
     /// UTF-8 error
     #[error("UTF-8 error: {0}")]
     Utf8Error(String),
-    
+
     /// Unexpected response
     #[error("Unexpected response: {0}")]
     UnexpectedResponse(String),
-    
+
     /// I/O error
     #[error("I/O error: {0}")]
     IoError(String),
-    
+
     /// WebSocket error
     #[error("WebSocket error: {0}")]
     WebSocketError(String),
-    
+
     /// Unknown error
     #[error("Unknown error: {0}")]
     Other(String),
@@ -116,11 +116,11 @@ pub enum WebsocketError {
     /// JSON error
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
-    
+
     /// Connection error
     #[error("Connection error: {0}")]
     ConnectionError(#[from] tokio_tungstenite::tungstenite::Error),
-    
+
     /// Unsupported message type
     #[error("Unsupported message type")]
     UnsupportedMessageType,


### PR DESCRIPTION
# Improve engine_api errors

Improve errors in engine_api [#326](https://github.com/exein-io/pulsar/issues/326)

(this is my second time trying to contribute, feedback is welcome)

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [x] linked to the originating issue (if applicable).
