### PR TITLE
Fix: add missing dash in riscv64 architecture string

### DIFF
--- a/.github/release-assets/pulsar-install.sh
+++ b/.github/release-assets/pulsar-install.sh
@@ -255,7 +255,7 @@ get_release_variant() {
 
         riscv64)
             #_cputype=riscv64gc
-            _arch=riscv64gc
+            _arch=-riscv64gc
             ;;
 
         *)


### PR DESCRIPTION
# Fix: add missing dash in riscv64 architecture string

## Description

When installing Pulsar on a riscv64 architecture using the command:

```bash
curl --proto '=https' --tlsv1.2 -LsSf https://github.com/exein-io/pulsar/releases/latest/download/pulsar-install.sh | sh
```
the following error occurs: 
```bash 
pulsar-install: command failed: downloader https://github.com/exein-io/pulsar/releases/download/v0.9.0/pulsar-execriscv64gc /tmp/tmp.ibEXkx/pulsar-exec
```

This is caused by a missing dash (-) in the architecture string inside function 'get_release_variant()' in pulsar-install.sh.

This fix adds the missing dash to the riscv64 architecture string, resolving the issue.
