### PR TITLE
feat: Dependency on other modules

### DIFF
--- a/crates/modules/desktop-notifier/src/lib.rs
+++ b/crates/modules/desktop-notifier/src/lib.rs
@@ -17,6 +17,7 @@ impl SimplePulsarModule for DesktopNotifierModule {
 
     const MODULE_NAME: &'static str = "desktop-notifier";
     const DEFAULT_ENABLED: bool = false;
+    const DEPENDS_ON: &'static [&'static str] = &[];
 
     async fn init_state(
         &self,

--- a/crates/modules/file-system-monitor/src/lib.rs
+++ b/crates/modules/file-system-monitor/src/lib.rs
@@ -97,6 +97,7 @@ pub mod pulsar {
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;
+        const DEPENDS_ON: &'static [&'static str] = &["process-monitor"];
 
         async fn init_state(
             &self,

--- a/crates/modules/network-monitor/src/lib.rs
+++ b/crates/modules/network-monitor/src/lib.rs
@@ -225,6 +225,7 @@ pub mod pulsar {
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;
+        const DEPENDS_ON: &'static [&'static str] = &["process-monitor"];
 
         async fn init_state(
             &self,

--- a/crates/modules/process-monitor/src/lib.rs
+++ b/crates/modules/process-monitor/src/lib.rs
@@ -153,6 +153,7 @@ pub mod pulsar {
 
         const MODULE_NAME: &'static str = MODULE_NAME;
         const DEFAULT_ENABLED: bool = true;
+        const DEPENDS_ON: &'static [&'static str] = &[];
 
         async fn init_state(
             &self,

--- a/crates/modules/rules-engine/src/lib.rs
+++ b/crates/modules/rules-engine/src/lib.rs
@@ -21,6 +21,7 @@ impl SimplePulsarModule for RuleEngineModule {
 
     const MODULE_NAME: &'static str = "rules-engine";
     const DEFAULT_ENABLED: bool = true;
+    const DEPENDS_ON: &'static [&'static str] = &[];
 
     async fn init_state(
         &self,

--- a/crates/modules/smtp-notifier/src/lib.rs
+++ b/crates/modules/smtp-notifier/src/lib.rs
@@ -21,6 +21,7 @@ impl SimplePulsarModule for SmtpNotifierModule {
 
     const MODULE_NAME: &'static str = "smtp-notifier";
     const DEFAULT_ENABLED: bool = false;
+    const DEPENDS_ON: &'static [&'static str] = &[];
 
     async fn init_state(
         &self,

--- a/crates/modules/threat-logger/src/lib.rs
+++ b/crates/modules/threat-logger/src/lib.rs
@@ -27,6 +27,7 @@ impl SimplePulsarModule for ThreatLoggerModule {
 
     const MODULE_NAME: &'static str = "threat-logger";
     const DEFAULT_ENABLED: bool = true;
+    const DEPENDS_ON: &'static [&'static str] = &[];
 
     async fn init_state(
         &self,

--- a/crates/pulsar-core/src/pdk/daemon.rs
+++ b/crates/pulsar-core/src/pdk/daemon.rs
@@ -43,8 +43,12 @@ impl PulsarDaemonHandle {
         recv.await.expect("Actor task has been killed")
     }
 
-    pub async fn status(&self, module_name: String) -> Result<ModuleStatus, PulsarDaemonError> {
+    pub async fn status<S>(&self, module_name: S) -> Result<ModuleStatus, PulsarDaemonError>
+    where
+        S: Into<String>,
+    {
         let (send, recv) = oneshot::channel();
+        let module_name = module_name.into();
         let msg = PulsarDaemonCommand::Status {
             tx_reply: send,
             module_name,

--- a/crates/pulsar-core/src/pdk/module.rs
+++ b/crates/pulsar-core/src/pdk/module.rs
@@ -28,6 +28,7 @@ pub trait PulsarModule: Send {
 
     const MODULE_NAME: &'static str;
     const DEFAULT_ENABLED: bool;
+    const DEPENDS_ON: &'static [&'static str];
 
     fn init_state(
         &self,
@@ -79,6 +80,7 @@ pub trait SimplePulsarModule: Send + Sync {
 
     const MODULE_NAME: &'static str;
     const DEFAULT_ENABLED: bool;
+    const DEPENDS_ON: &'static [&'static str];
 
     fn init_state(
         &self,
@@ -124,8 +126,8 @@ where
     type TriggerOutput = ();
 
     const MODULE_NAME: &'static str = Self::MODULE_NAME;
-
     const DEFAULT_ENABLED: bool = Self::DEFAULT_ENABLED;
+    const DEPENDS_ON: &'static [&'static str] = Self::DEPENDS_ON;
 
     async fn init_state(
         &self,

--- a/examples/pulsar-embedded-agent/proxy_module.rs
+++ b/examples/pulsar-embedded-agent/proxy_module.rs
@@ -11,6 +11,7 @@ impl SimplePulsarModule for ProxyModule {
 
     const MODULE_NAME: &'static str = "proxy-module";
     const DEFAULT_ENABLED: bool = true;
+    const DEPENDS_ON: &'static [&'static str] = &[];
 
     async fn init_state(
         &self,

--- a/examples/pulsar-extension-module/my_custom_module.rs
+++ b/examples/pulsar-extension-module/my_custom_module.rs
@@ -13,6 +13,7 @@ impl SimplePulsarModule for MyCustomModule {
 
     const MODULE_NAME: &'static str = "my-custom-module";
     const DEFAULT_ENABLED: bool = true;
+    const DEPENDS_ON: &'static [&'static str] = &[];
 
     async fn init_state(
         &self,


### PR DESCRIPTION
Allow modules to be dependent on others by adding the `DEPENDS_ON` constant to `PulsarModule` and `SimplePulsarModule` traits. This constant can be set either as empty (`&[]`) or can specify dependencies (e.g. `&["process-monitor"]`, `&["process-monitor", "network-monitor"]`).

Make `file-system-monitor` and `network-monitor` dependent on `process-monitor`. This way we get rid of the race condition, where these modules start before `process-monitor`, generating errors like:

```
Process not found in tracker 63980: process not found
```

These errors are not there anymore after introducing the dependency.

## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
