### PR TITLE
switch cross container to clang 20

### DIFF
--- a/.cross/README.md
+++ b/.cross/README.md
@@ -1,9 +1,9 @@
 # Cross containers
 
-These containers are used in conjunction with [cross](https://github.com/cross-rs/cross) to build Pulsar in a reproducible way without worrying about system dependencies. 
+These containers are used in conjunction with [cross](https://github.com/cross-rs/cross) to build Pulsar in a reproducible way without worrying about system dependencies.
 
 Containers are based on the default [cross containers](https://github.com/orgs/cross-rs/packages) built from `Ubuntu 20.04 LTS`, with the addition of:
 
--   `Clang/LLVM 19`
+-   `Clang/LLVM 20`
 -   `libssl-dev` speficic for the target architecture, example `libssl-dev:arm64`
 -   `libsqlite3-dev` speficic for the target architecture, example `libsqlite3-dev:arm64`

--- a/.cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/.cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -9,6 +9,6 @@ RUN dpkg --add-architecture arm64 && \
         gnupg \
         libssl-dev:arm64 \
         libsqlite3-dev:arm64 \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 19 \
-    && ln -s /usr/bin/clang-19 /usr/bin/clang \
-    && ln -s /usr/bin/llvm-strip-19 /usr/bin/llvm-strip
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 \
+    && ln -s /usr/bin/clang-20 /usr/bin/clang \
+    && ln -s /usr/bin/llvm-strip-20 /usr/bin/llvm-strip

--- a/.cross/aarch64-unknown-linux-musl.Dockerfile
+++ b/.cross/aarch64-unknown-linux-musl.Dockerfile
@@ -7,6 +7,6 @@ RUN dpkg --add-architecture arm64 && \
         wget \
         software-properties-common \
         gnupg \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 19 \
-    && ln -s /usr/bin/clang-19 /usr/bin/clang \
-    && ln -s /usr/bin/llvm-strip-19 /usr/bin/llvm-strip
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 \
+    && ln -s /usr/bin/clang-20 /usr/bin/clang \
+    && ln -s /usr/bin/llvm-strip-20 /usr/bin/llvm-strip

--- a/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
+++ b/.cross/riscv64gc-unknown-linux-gnu.Dockerfile
@@ -9,6 +9,6 @@ RUN dpkg --add-architecture riscv64 && \
         gnupg \
         libssl-dev:riscv64 \
         libsqlite3-dev:riscv64 \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 19 \
-    && ln -s /usr/bin/clang-19 /usr/bin/clang \
-    && ln -s /usr/bin/llvm-strip-19 /usr/bin/llvm-strip
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 \
+    && ln -s /usr/bin/clang-20 /usr/bin/clang \
+    && ln -s /usr/bin/llvm-strip-20 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/.cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -8,6 +8,6 @@ RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome >
         gnupg \
         libssl-dev \
         libsqlite3-dev \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 19 \
-    && ln -s /usr/bin/clang-19 /usr/bin/clang \
-    && ln -s /usr/bin/llvm-strip-19 /usr/bin/llvm-strip
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 \
+    && ln -s /usr/bin/clang-20 /usr/bin/clang \
+    && ln -s /usr/bin/llvm-strip-20 /usr/bin/llvm-strip

--- a/.cross/x86_64-unknown-linux-musl.Dockerfile
+++ b/.cross/x86_64-unknown-linux-musl.Dockerfile
@@ -6,6 +6,6 @@ RUN ln -snf /usr/share/zoneinfo/Europe/Rome /etc/localtime && echo Europe/Rome >
         wget \
         software-properties-common \
         gnupg \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 19 \
-    && ln -s /usr/bin/clang-19 /usr/bin/clang \
-    && ln -s /usr/bin/llvm-strip-19 /usr/bin/llvm-strip
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 20 \
+    && ln -s /usr/bin/clang-20 /usr/bin/clang \
+    && ln -s /usr/bin/llvm-strip-20 /usr/bin/llvm-strip

--- a/crates/modules/process-monitor/probes.bpf.c
+++ b/crates/modules/process-monitor/probes.bpf.c
@@ -598,11 +598,12 @@ int BPF_PROG(sched_switch)
   struct ctx_orphan_adopted c;
   pid_t first = 0;
 
+#pragma unroll 5
   for (int i = 0; i < 5; i++)
   {
     if (bpf_map_pop_elem(&orphans_map, &c.pending))
     {
-      return 0;
+      break;
     }
     // Make sure the loop doesn't process the same dead parent multiple times
     if (first == 0)


### PR DESCRIPTION
Apparently `clang 20` doesn't unroll anymore loops `< 5` and so I added `#pragma unroll`. Then I noticed it was not enough:
```console
0: failed program load raw_tracepoint sched_switch
    1: the BPF_PROG_LOAD syscall failed. Verifier output: 16: for (int i = 0; i < 5; i++)
       17: if (bpf_map_pop_elem(&orphans_map, &c.pending))
       back-edge from insn 16 to 17
       verification time 3282 usec
       stack depth 0
       processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
```
probably because the loop iteration is too complex `clang` still refuses to unroll the loop; so I had to add an explicit `5` like this `#pragma unroll 5`