### PR TITLE
better handling signals in xtask surun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4064,6 +4064,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "indicatif",
+ "libc",
  "log",
  "num_cpus",
  "reqwest",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,3 +23,4 @@ uuid = { workspace = true, features = ["v4"] }
 xshell = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
+libc = { workspace = true }


### PR DESCRIPTION
This PR want to solve an issue that happens for example hitting CTRL-C on `xtask::surun` cmd. Right now when the child process doesn't terminate or needs more time the parent (xtask process) exits anyway giving you back the prompt and leaving the child process in background.

Here I changed how the signals are handled, only forwarding signals to the child process but keeping the parent waiting until the child process exits