### PR TITLE
fix module manager lock on waiting for init state function result

### DIFF
--- a/crates/pulsar-core/src/pdk/daemon.rs
+++ b/crates/pulsar-core/src/pdk/daemon.rs
@@ -153,6 +153,7 @@ impl PulsarDaemonHandle {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModuleStatus {
     Created,
+    Starting,
     Running(Vec<String>),
     Failed(String),
     Stopped,

--- a/src/pulsar/mod.rs
+++ b/src/pulsar/mod.rs
@@ -24,11 +24,11 @@ pub async fn pulsar_cli_run(options: &PulsarCliOpts) -> Result<()> {
         Commands::Status => engine_api_client.list_modules().await?.term_print(),
         Commands::Start { module_name } => {
             engine_api_client.start(module_name).await?;
-            "Module started".to_string().term_print()
+            "Module starting".to_string().term_print()
         }
         Commands::Restart { module_name } => {
             engine_api_client.restart(module_name).await?;
-            "Module restarted".to_string().term_print()
+            "Module restarting".to_string().term_print()
         }
         Commands::Stop { module_name } => {
             engine_api_client.stop(module_name).await?;

--- a/src/pulsar/term_print.rs
+++ b/src/pulsar/term_print.rs
@@ -35,6 +35,7 @@ impl TermPrintable for Vec<ModuleOverview> {
         for module in sorted {
             let status_color = match module.status {
                 ModuleStatus::Created => Color::White,
+                ModuleStatus::Starting => Color::Yellow,
                 ModuleStatus::Running(ref warnings) if warnings.is_empty() => Color::Green,
                 ModuleStatus::Running(_) => Color::Yellow,
                 ModuleStatus::Failed(_) => Color::Red,


### PR DESCRIPTION
Fix module not receiving stop signal while starting.

- Introduced a new module state starting and start asynchronously
- Listen for stop signals during initialization

