### PR TITLE
Update pulsar-install.sh to ensure proper quoting on _release_url variable

### DIFF
--- a/.github/release-assets/pulsar-install.sh
+++ b/.github/release-assets/pulsar-install.sh
@@ -101,7 +101,7 @@ main() {
     ensure downloader "https://github.com/exein-io/pulsar/releases/download/${PULSAR_VERSION}/pulsar${_arch}" "${_dir}/pulsar"
 
     # Download release archive
-    local _release_url=$(curl -s https://api.github.com/repos/exein-io/pulsar/releases/tags/${PULSAR_VERSION} | grep "tarball_url" | cut -d : -f 2,3 | tr -d , | tr -d \") 
+    local _release_url="$(curl -s https://api.github.com/repos/exein-io/pulsar/releases/tags/${PULSAR_VERSION} | grep "tarball_url" | cut -d : -f 2,3 | tr -d , | tr -d \")"
     local _tmp_pulsar_archive="${_dir}/pulsar.tar.gz"
     ensure downloader $_release_url $_tmp_pulsar_archive
 


### PR DESCRIPTION
# Ensure proper quoting on _release_url variable

Updated the release URL variable to be quoted so it works more consistently across different shells and operating systems. On an older Ubuntu 20.04 machine this line would previously produce the following error:

`sh: 103: local: https://api.github.com/repos/exein-io/pulsar/tarball/v0.9.0: bad variable name`

## I have 
- Tested installation on Ubuntu 20.04 (previously failing) and Debian 12.